### PR TITLE
Limit add disc flag lists by default

### DIFF
--- a/src/routes/disc_edit.rs
+++ b/src/routes/disc_edit.rs
@@ -241,6 +241,7 @@ pub(crate) struct CheckOption {
     pub code: String,
     pub selected: bool,
     pub highlight: String,
+    pub common: bool,
 }
 
 pub(crate) struct HighlightedValue {
@@ -490,6 +491,23 @@ pub(crate) fn build_category_options(
 }
 
 pub(crate) fn build_check_options(all: &[Region], selected_codes: &[String]) -> Vec<CheckOption> {
+    const COMMON_REGIONS: &[&str] = &[
+        "Asia",
+        "Australia",
+        "Europe",
+        "France",
+        "Germany",
+        "Italy",
+        "Japan",
+        "Korea",
+        "Netherlands",
+        "Poland",
+        "Portugal",
+        "Russia",
+        "Spain",
+        "UK",
+        "USA",
+    ];
     let mut options: Vec<CheckOption> = all
         .iter()
         .map(|r| CheckOption {
@@ -498,6 +516,7 @@ pub(crate) fn build_check_options(all: &[Region], selected_codes: &[String]) -> 
             code: r.flag_code.trim().to_lowercase(),
             selected: selected_codes.iter().any(|c| c.trim() == r.code.trim()),
             highlight: String::new(),
+            common: COMMON_REGIONS.iter().any(|name| *name == r.name),
         })
         .collect();
     options.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
@@ -508,6 +527,23 @@ pub(crate) fn build_lang_check_options(
     all: &[Language],
     selected_codes: &[String],
 ) -> Vec<CheckOption> {
+    const COMMON_LANGUAGES: &[&str] = &[
+        "Danish",
+        "Dutch",
+        "English",
+        "Finnish",
+        "French",
+        "German",
+        "Italian",
+        "Japanese",
+        "Korean",
+        "Norwegian",
+        "Polish",
+        "Portuguese",
+        "Russian",
+        "Spanish",
+        "Swedish",
+    ];
     let mut options: Vec<CheckOption> = all
         .iter()
         .map(|l| CheckOption {
@@ -516,6 +552,7 @@ pub(crate) fn build_lang_check_options(
             code: l.flag_code.trim().to_lowercase(),
             selected: selected_codes.iter().any(|c| c.trim() == l.code.trim()),
             highlight: String::new(),
+            common: COMMON_LANGUAGES.iter().any(|name| *name == l.name),
         })
         .collect();
     options.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1919,6 +1919,24 @@ body:has(.disc-edit) footer.container hr {
     column-gap: 0.85rem;
     margin-bottom: 0;
 }
+.flag-list-controls {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 0.45rem;
+}
+.flag-list-toggle {
+    width: auto;
+    margin: 0;
+    padding: 0.22rem 0.55rem;
+    font-size: 0.72rem;
+}
+.disc-edit.disc-add:not(.show-all-flags) .flag-check-extra {
+    display: none !important;
+}
+.disc-edit.disc-add:not(.show-all-flags) .flag-check-list {
+    columns: 1;
+    max-width: max-content;
+}
 .flag-select-languages {
     border-left: 1px solid #d7e1ea;
     padding-left: 0.85rem;

--- a/static/js/disc_edit.js
+++ b/static/js/disc_edit.js
@@ -179,6 +179,51 @@ function initSubmitAsSelector() {
     attachSubmitAsSelector(document.getElementById('submit-as-input'));
 }
 
+var FLAG_LIST_STORAGE_KEY = 'vgindex.addDisc.showAllFlags';
+
+function flagListPreference() {
+    try {
+        return window.localStorage && window.localStorage.getItem(FLAG_LIST_STORAGE_KEY) === 'true';
+    } catch (e) {
+        return false;
+    }
+}
+
+function saveFlagListPreference(showAll) {
+    try {
+        if (window.localStorage) {
+            window.localStorage.setItem(FLAG_LIST_STORAGE_KEY, showAll ? 'true' : 'false');
+        }
+    } catch (e) {
+        // Ignore storage failures; the current-page toggle still works.
+    }
+}
+
+function setFlagListExpanded(showAll) {
+    var form = document.getElementById('disc-edit-form');
+    var toggle = document.getElementById('flag-list-toggle');
+    if (!form || !toggle) return;
+
+    form.classList.toggle('show-all-flags', showAll);
+    toggle.setAttribute('aria-expanded', showAll ? 'true' : 'false');
+    toggle.textContent = showAll
+        ? (toggle.dataset.showCommonLabel || 'Show popular regions and languages')
+        : (toggle.dataset.showAllLabel || 'Show all regions and languages');
+}
+
+function initFlagListToggle() {
+    var toggle = document.getElementById('flag-list-toggle');
+    if (!toggle) return;
+
+    setFlagListExpanded(flagListPreference());
+    toggle.addEventListener('click', function () {
+        var form = document.getElementById('disc-edit-form');
+        var showAll = !(form && form.classList.contains('show-all-flags'));
+        setFlagListExpanded(showAll);
+        saveFlagListPreference(showAll);
+    });
+}
+
 // Vertical repeatable array field (layerbreaks)
 function addArrayEntry(containerId, name) {
     var container = document.getElementById(containerId);
@@ -836,6 +881,7 @@ document.addEventListener('DOMContentLoaded', function () {
     initAutoExpand();
     initEditionSelectors();
     initSubmitAsSelector();
+    initFlagListToggle();
     initIndependentInlineResizing();
     fitDiscMetaFields();
     fitAllInlineGroups();

--- a/templates/disc_edit.html
+++ b/templates/disc_edit.html
@@ -218,13 +218,18 @@ const IS_ADD_MODE = {{ is_add_mode }};
     </div>
 
     <div class="disc-form-section" aria-label="Regions and languages">
+    {% if is_add_mode %}
+    <div class="flag-list-controls">
+        <button type="button" id="flag-list-toggle" class="outline secondary flag-list-toggle" aria-expanded="false" data-show-all-label="Show all regions and languages" data-show-common-label="Show popular regions and languages">Show all regions and languages</button>
+    </div>
+    {% endif %}
     <div class="grid flag-select-grid">
         <div class="flag-select-group flag-select-regions{% if !self.highlight_class("regions").is_empty() %} {{ self.highlight_class("regions") }}{% endif %}">
         <fieldset>
             <legend>Regions:</legend>
             <div class="flag-check-list">
             {% for r in regions %}
-                <label class="flag-check{% if r.name == "Japan" || r.name == "Europe" || r.name == "USA" || r.name == "UK" || r.name == "France" || r.name == "Germany" || r.name == "Italy" || r.name == "Spain" %} flag-check-emphasis{% endif %}{% if !r.highlight.is_empty() %} item-{{ r.highlight }}{% endif %}">
+                <label class="flag-check{% if is_add_mode && !r.common && !r.selected %} flag-check-extra{% endif %}{% if !r.highlight.is_empty() %} item-{{ r.highlight }}{% endif %}">
                     <input type="{% if is_add_mode %}radio{% else %}checkbox{% endif %}" name="regions" value="{{ r.value }}" {% if r.selected %}checked{% endif %}>
                     <img class="flag-icon" src="/static/flags/{{ r.code }}.svg" title="{{ r.name }}" alt="{{ r.name }}">
                     <span>{{ r.name }}</span>
@@ -248,7 +253,7 @@ const IS_ADD_MODE = {{ is_add_mode }};
             <legend>Languages:</legend>
             <div class="flag-check-list">
             {% for lang in languages %}
-                <label class="flag-check{% if lang.name == "Japanese" || lang.name == "English" || lang.name == "German" || lang.name == "Spanish" || lang.name == "Italian" || lang.name == "French" %} flag-check-emphasis{% endif %}{% if !lang.highlight.is_empty() %} item-{{ lang.highlight }}{% endif %}">
+                <label class="flag-check{% if is_add_mode && !lang.common && !lang.selected %} flag-check-extra{% endif %}{% if !lang.highlight.is_empty() %} item-{{ lang.highlight }}{% endif %}">
                     <input type="checkbox" name="languages" value="{{ lang.value }}" {% if lang.selected %}checked{% endif %}>
                     <img class="flag-icon" src="/static/flags/{{ lang.code }}.svg" title="{{ lang.name }}" alt="{{ lang.name }}">
                     <span>{{ lang.name }}</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Show all regions and languages" toggle to the disc edit form. Users can now switch between viewing common options and the full list, with their preference automatically saved and restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->