### PR TITLE
Foreign Title → Title transliteration (Japanese, Russian, Greek)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +283,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -284,6 +312,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +353,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -332,6 +385,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +417,16 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -411,6 +493,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "daachorse"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db756b5eb7d81d31f31f660f4132f8cf5698de52fca144c143d0ae0cbb5f2e06"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +582,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -471,6 +646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -527,6 +717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +773,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -690,6 +902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +925,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +944,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -987,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1278,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1358,15 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1098,7 +1402,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1113,6 +1417,87 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "lindera"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74cda79d7161e99b414e4d292ff673cc3f8d22f070d8be3b6185c033363a9216"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "kanaria",
+ "lindera-dictionary",
+ "lindera-ipadic",
+ "log",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "strum",
+ "strum_macros",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "url",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2385456ca9fe87c29072c5f156b52fdd5e28d5b5738ddfb3979501dbd736530"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "derive_builder",
+ "encoding_rs",
+ "encoding_rs_io",
+ "flate2",
+ "glob",
+ "log",
+ "md5",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "rand 0.10.1",
+ "regex",
+ "reqwest 0.13.4",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "tar",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130c598519a40bbfb762c4c06d6ad29315331eb4c154fcb2d1d6b46776cee7d9"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1167,10 +1552,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1206,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1230,6 +1630,26 @@ dependencies = [
  "mime",
  "spin 0.9.8",
  "version_check",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1314,10 +1734,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking"
@@ -1461,6 +1897,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1942,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -1537,6 +1994,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +2021,15 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1596,12 +2071,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1610,7 +2091,19 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1629,6 +2122,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -1669,6 +2171,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +2232,36 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1730,17 +2297,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1754,11 +2356,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -1777,10 +2407,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1868,6 +2539,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2613,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -2089,7 +2789,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2133,7 +2833,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -2208,6 +2908,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2969,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2331,9 +3069,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2348,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2413,7 +3151,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2534,6 +3272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,10 +3299,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2642,9 +3398,10 @@ dependencies = [
  "hex",
  "http",
  "jsonwebtoken",
+ "lindera",
  "md-5",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "roxmltree",
  "serde",
  "serde_json",
@@ -2660,6 +3417,16 @@ dependencies = [
  "urlencoding",
  "uuid",
  "zip",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2788,7 +3555,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2812,6 +3579,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2857,6 +3633,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3138,7 +3923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -3173,6 +3958,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ jsonwebtoken = "8"
 urlencoding = "2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 roxmltree = "0.20"
+lindera = { version = "3", features = ["embed-ipadic"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM rust:1.85-bookworm AS builder
+# Rust >= 1.86 required: lindera pulls ICU 2.x (rust-version 1.86); the lockfile
+# targets the 1.94 toolchain. Bump in lockstep if you change the Rust version.
+FROM rust:1.94-bookworm AS builder
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock* ./

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod db;
 mod error;
 mod routes;
 mod services;
+mod transliteration;
 
 use axum::{middleware, Router};
 use sqlx::PgPool;
@@ -24,6 +25,7 @@ pub struct AppState {
     pub archive_tx: tokio::sync::mpsc::UnboundedSender<String>,
     pub edition_suggestions: services::disc_service::EditionSuggestionsCache,
     pub news_cache: services::news_service::NewsCache,
+    pub transliteration: Arc<transliteration::TransliterationRegistry>,
 }
 
 #[tokio::main]
@@ -49,6 +51,11 @@ async fn main() {
 
     std::fs::create_dir_all(config::DATA_DIR).ok();
 
+    let transliteration = Arc::new(
+        transliteration::TransliterationRegistry::new()
+            .expect("Failed to initialize transliteration registry"),
+    );
+
     let (archive_tx, archive_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
     let state = AppState {
@@ -62,6 +69,7 @@ async fn main() {
         news_cache: services::news_service::NewsCache::new(Duration::from_secs(
             services::news_service::NEWS_FEED_TTL_SECONDS,
         )),
+        transliteration,
     };
 
     tokio::spawn(run_session_cleanup(pool.clone()));

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -1,6 +1,13 @@
-use axum::{extract::State, response::Html, routing::get, Json, Router};
+use axum::{
+    extract::State,
+    response::Html,
+    routing::{get, post},
+    Json, Router,
+};
 
-use crate::auth::middleware::CurrentUser;
+use crate::auth::middleware::{CurrentUser, RequireAuth};
+use crate::error::AppError;
+use crate::transliteration::{Script, TransliterationError};
 use crate::AppState;
 
 // Online means sessions active in this window: registered users are deduped by
@@ -11,6 +18,47 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/online", get(online_users))
         .route("/api/online-html", get(online_users_html))
+        .route("/api/transliterate", post(transliterate))
+}
+
+/// Transliterate a non-Latin title (currently Japanese) into a Latin-script
+/// draft for the Main Title field. Auth-gated: it's an editor helper.
+async fn transliterate(
+    State(state): State<AppState>,
+    _user: RequireAuth,
+    Json(req): Json<TransliterateRequest>,
+) -> Result<Json<TransliterateResponse>, AppError> {
+    let result = state
+        .transliteration
+        .transliterate(&req.text, req.script)
+        .map_err(|e| match e {
+            // Nothing to romanize (empty, or already Latin) is a client problem.
+            TransliterationError::EmptyInput | TransliterationError::UnsupportedScript => {
+                AppError::BadRequest(e.to_string())
+            }
+            TransliterationError::Backend(msg) => AppError::Internal(msg),
+        })?;
+
+    Ok(Json(TransliterateResponse {
+        text: result.text,
+        script: result.script,
+        notes: result.notes,
+    }))
+}
+
+#[derive(serde::Deserialize)]
+struct TransliterateRequest {
+    text: String,
+    /// Optional explicit script; auto-detected when omitted.
+    #[serde(default)]
+    script: Option<Script>,
+}
+
+#[derive(serde::Serialize)]
+struct TransliterateResponse {
+    text: String,
+    script: Script,
+    notes: Vec<String>,
 }
 
 async fn online_users(State(state): State<AppState>) -> Json<OnlineInfo> {

--- a/src/transliteration/detect.rs
+++ b/src/transliteration/detect.rs
@@ -1,0 +1,63 @@
+//! Lightweight writing-system detection.
+//!
+//! Used when the caller doesn't specify a script explicitly. Counts characters
+//! by Unicode block and returns the dominant *supported* script, or `None` if
+//! the text has nothing transliterable (e.g. it's already Latin).
+//!
+//! As new backends are added (Greek, Cyrillic, Chinese), extend `Counts` and the
+//! resolution logic here.
+
+use super::Script;
+
+#[derive(Default)]
+struct Counts {
+    kana: usize,
+    han: usize,
+    // future: greek, cyrillic, ...
+}
+
+fn tally(input: &str) -> Counts {
+    let mut c = Counts::default();
+    for ch in input.chars() {
+        let u = ch as u32;
+        match u {
+            // Hiragana + Katakana (+ Katakana phonetic extensions).
+            0x3040..=0x30FF | 0x31F0..=0x31FF => c.kana += 1,
+            // CJK Unified Ideographs (+ Extension A).
+            0x3400..=0x4DBF | 0x4E00..=0x9FFF => c.han += 1,
+            _ => {}
+        }
+    }
+    c
+}
+
+/// Detect the dominant supported script, or `None` if nothing is transliterable.
+pub fn detect_script(input: &str) -> Option<Script> {
+    let c = tally(input);
+    // Any kana is a strong Japanese signal. Han-only is ambiguous (could be
+    // Chinese); until a Chinese backend exists we treat CJK as Japanese, which
+    // matches this project's catalog focus.
+    if c.kana > 0 || c.han > 0 {
+        Some(Script::Japanese)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_japanese() {
+        assert_eq!(detect_script("悪魔城ドラキュラ"), Some(Script::Japanese));
+        assert_eq!(detect_script("ひらがな"), Some(Script::Japanese));
+        assert_eq!(detect_script("漢字"), Some(Script::Japanese));
+    }
+
+    #[test]
+    fn latin_is_not_transliterable() {
+        assert_eq!(detect_script("Dracula"), None);
+        assert_eq!(detect_script("Final Fantasy VII"), None);
+    }
+}

--- a/src/transliteration/detect.rs
+++ b/src/transliteration/detect.rs
@@ -13,7 +13,8 @@ use super::Script;
 struct Counts {
     kana: usize,
     han: usize,
-    // future: greek, cyrillic, ...
+    cyrillic: usize,
+    greek: usize,
 }
 
 fn tally(input: &str) -> Counts {
@@ -25,6 +26,10 @@ fn tally(input: &str) -> Counts {
             0x3040..=0x30FF | 0x31F0..=0x31FF => c.kana += 1,
             // CJK Unified Ideographs (+ Extension A).
             0x3400..=0x4DBF | 0x4E00..=0x9FFF => c.han += 1,
+            // Cyrillic (+ supplement).
+            0x0400..=0x04FF | 0x0500..=0x052F => c.cyrillic += 1,
+            // Greek (+ Coptic block).
+            0x0370..=0x03FF | 0x1F00..=0x1FFF => c.greek += 1,
             _ => {}
         }
     }
@@ -34,6 +39,15 @@ fn tally(input: &str) -> Counts {
 /// Detect the dominant supported script, or `None` if nothing is transliterable.
 pub fn detect_script(input: &str) -> Option<Script> {
     let c = tally(input);
+    // Cyrillic -> Russian (the only Cyrillic backend for now).
+    if c.cyrillic > 0 && c.cyrillic >= c.kana && c.cyrillic >= c.han {
+        return Some(Script::Russian);
+    }
+    // Greek script present and dominant over CJK -> Greek. (Lone Greek symbols
+    // inside a Japanese title stay Japanese because kana dominates.)
+    if c.greek > 0 && c.greek >= c.kana && c.greek >= c.han {
+        return Some(Script::Greek);
+    }
     // Any kana is a strong Japanese signal. Han-only is ambiguous (could be
     // Chinese); until a Chinese backend exists we treat CJK as Japanese, which
     // matches this project's catalog focus.

--- a/src/transliteration/greek.rs
+++ b/src/transliteration/greek.rs
@@ -1,0 +1,121 @@
+//! Greek transliteration — expands each Greek letter to its **English name**
+//! (α -> Alpha, Σ -> Sigma, Φ -> Phi …).
+//!
+//! In this catalog Greek letters appear almost exclusively as *symbols* in
+//! otherwise-Latin/Japanese titles (e.g. "Super Robot Taisen α" -> "…Alpha",
+//! "Ninja Gaiden Σ" -> "…Sigma"), so the useful behavior is letter-name
+//! expansion rather than phonetic romanization. Names are always capitalized.
+//! Non-Greek characters pass through; spacing is inserted so a name never fuses
+//! with adjacent alphanumerics ("30Φ" -> "30 Phi").
+
+use super::{Script, TransliterationError, TransliterationOutput, Transliterator};
+
+pub struct GreekTransliterator;
+
+impl GreekTransliterator {
+    pub fn new() -> Self {
+        GreekTransliterator
+    }
+}
+
+impl Transliterator for GreekTransliterator {
+    fn script(&self) -> Script {
+        Script::Greek
+    }
+
+    fn transliterate(&self, input: &str) -> Result<TransliterationOutput, TransliterationError> {
+        let mut out = String::with_capacity(input.len() * 4);
+        let mut prev_was_name = false;
+
+        for c in input.chars() {
+            if let Some(name) = letter_name(c) {
+                // Space before the name if it would fuse with a letter/digit.
+                if out.chars().last().is_some_and(|p| p.is_alphanumeric()) {
+                    out.push(' ');
+                }
+                out.push_str(name);
+                prev_was_name = true;
+            } else {
+                // Space after a name if the next char is a letter/digit.
+                if prev_was_name && c.is_alphanumeric() {
+                    out.push(' ');
+                }
+                out.push(c);
+                prev_was_name = false;
+            }
+        }
+
+        Ok(TransliterationOutput {
+            text: out,
+            script: Script::Greek,
+            notes: Vec::new(),
+        })
+    }
+}
+
+/// English name of a Greek letter (case-insensitive, accents folded). None for
+/// non-Greek characters.
+fn letter_name(c: char) -> Option<&'static str> {
+    let lower = c.to_lowercase().next().unwrap_or(c);
+    Some(match lower {
+        'α' | 'ά' => "Alpha",
+        'β' => "Beta",
+        'γ' => "Gamma",
+        'δ' => "Delta",
+        'ε' | 'έ' => "Epsilon",
+        'ζ' => "Zeta",
+        'η' | 'ή' => "Eta",
+        'θ' => "Theta",
+        'ι' | 'ί' | 'ϊ' | 'ΐ' => "Iota",
+        'κ' => "Kappa",
+        'λ' => "Lambda",
+        'μ' => "Mu",
+        'ν' => "Nu",
+        'ξ' => "Xi",
+        'ο' | 'ό' => "Omicron",
+        'π' => "Pi",
+        'ρ' => "Rho",
+        'σ' | 'ς' => "Sigma",
+        'τ' => "Tau",
+        'υ' | 'ύ' | 'ϋ' | 'ΰ' => "Upsilon",
+        'φ' => "Phi",
+        'χ' => "Chi",
+        'ψ' => "Psi",
+        'ω' | 'ώ' => "Omega",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tr(s: &str) -> String {
+        GreekTransliterator.transliterate(s).unwrap().text
+    }
+
+    #[test]
+    fn single_letter_symbols() {
+        assert_eq!(tr("α"), "Alpha");
+        assert_eq!(tr("Σ"), "Sigma");
+        assert_eq!(tr("Super Robot Taisen α"), "Super Robot Taisen Alpha");
+        assert_eq!(tr("Ninja Gaiden Σ"), "Ninja Gaiden Sigma");
+    }
+
+    #[test]
+    fn spacing_inserted_around_names() {
+        assert_eq!(tr("30Φ"), "30 Phi");
+        assert_eq!(tr("αβ"), "Alpha Beta");
+    }
+
+    #[test]
+    fn full_greek_word_expands_each_letter() {
+        // Accepted tradeoff: real Greek words become letter sequences.
+        assert_eq!(tr("ΓΑΛΕΟΖ"), "Gamma Alpha Lambda Epsilon Omicron Zeta");
+    }
+
+    #[test]
+    fn passthrough() {
+        assert_eq!(tr("Final Fantasy"), "Final Fantasy");
+    }
+}

--- a/src/transliteration/japanese/mod.rs
+++ b/src/transliteration/japanese/mod.rs
@@ -420,6 +420,90 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "bugcheck: TITLES_TSV=/tmp/jp_pairs.tsv cargo test ... bugcheck -- --ignored --nocapture"]
+    fn bugcheck() {
+        use rand::seq::SliceRandom;
+        let path = std::env::var("TITLES_TSV").unwrap_or_default();
+        if path.is_empty() {
+            return;
+        }
+        let data = std::fs::read_to_string(&path).unwrap();
+        let t = t();
+        let is_kana = |c: char| matches!(c as u32, 0x3040..=0x30FF | 0x31F0..=0x31FF);
+        let is_kanji = |c: char| matches!(c as u32, 0x3400..=0x4DBF | 0x4E00..=0x9FFF);
+
+        let mut kana_leak = Vec::new(); // real bug: untranslated kana in output
+        let mut kanji_leak = Vec::new(); // missing dictionary reading
+        let mut all: Vec<(String, String)> = Vec::new();
+        let mut n = 0u64;
+        for line in data.lines() {
+            let Some((fg, ti)) = line.split_once('\t') else { continue };
+            let Ok(out) = t.transliterate(fg) else { continue };
+            n += 1;
+            let txt = out.text;
+            if txt.chars().any(|c| c != 'ー' && is_kana(c)) {
+                kana_leak.push((fg.to_string(), txt.clone()));
+            } else if txt.chars().any(is_kanji) {
+                kanji_leak.push((fg.to_string(), txt.clone()));
+            }
+            all.push((fg.to_string(), txt));
+            let _ = ti;
+        }
+
+        println!("\n== bug scan over {n} entries ==");
+        println!("kana leaks (BUG):     {}", kana_leak.len());
+        println!("kanji leaks (no reading): {}", kanji_leak.len());
+
+        println!("\n-- sample kana leaks (if any) --");
+        for (fg, txt) in kana_leak.iter().take(15) {
+            println!("  {fg}  ->  {txt}");
+        }
+        println!("\n-- sample kanji leaks --");
+        for (fg, txt) in kanji_leak.iter().take(15) {
+            println!("  {fg}  ->  {txt}");
+        }
+
+        println!("\n-- 50 random samples (eyeball) --");
+        let mut rng = rand::thread_rng();
+        for (fg, txt) in all.choose_multiple(&mut rng, 50) {
+            let flag = if txt.chars().any(|c| c != 'ー' && (is_kana(c) || is_kanji(c))) {
+                "   <== LEFTOVER"
+            } else {
+                ""
+            };
+            println!("  {fg}  ->  {txt}{flag}");
+        }
+    }
+
+    #[test]
+    #[ignore = "sample: TITLES_TSV=/tmp/jp_pairs.tsv cargo test ... sample_mismatches -- --ignored --nocapture"]
+    fn sample_mismatches() {
+        use rand::seq::SliceRandom;
+        let path = std::env::var("TITLES_TSV").unwrap_or_default();
+        if path.is_empty() {
+            return;
+        }
+        let data = std::fs::read_to_string(&path).unwrap();
+        let t = t();
+        let mut miss: Vec<(String, String, String)> = Vec::new(); // (jp, engine, curated)
+        for line in data.lines() {
+            let Some((fg, ti)) = line.split_once('\t') else { continue };
+            let Ok(out) = t.transliterate(fg) else { continue };
+            if out.text.to_lowercase() != ti.to_lowercase() {
+                miss.push((fg.to_string(), out.text.clone(), ti.to_string()));
+            }
+        }
+        let mut rng = rand::thread_rng();
+        let picks: Vec<_> = miss.choose_multiple(&mut rng, 10).cloned().collect();
+        for (jp, eng, cur) in picks {
+            println!("Redump.org Entry title: {cur}");
+            println!("Transliterate function title: {eng}");
+            println!("Japanese title: {jp}");
+            println!();
+        }
+    }
+
+    #[test]
     #[ignore = "mining: TITLES_TSV=/tmp/jp_pairs.tsv cargo test ... mine_compounds -- --ignored --nocapture"]
     fn mine_compounds() {
         let path = std::env::var("TITLES_TSV").unwrap_or_default();
@@ -563,6 +647,7 @@ mod tests {
             "『夢』・島",
             "ＲＰＧ ２",
             "悪魔城ドラキュラ　Ｘ～月下の夜想曲～　オリジナル・ゲーム・サントラ",
+            "コール オブ デューティー:ファイネスト アワー",
         ] {
             let out = t.transliterate(s).unwrap();
             println!("{s}  ->  {}", out.text);

--- a/src/transliteration/japanese/mod.rs
+++ b/src/transliteration/japanese/mod.rs
@@ -1,0 +1,571 @@
+//! Japanese transliteration backend (modified Hepburn, title style).
+//!
+//! Pipeline for a Foreign Title:
+//! 1. Normalize the input (`normalize`): fullwidth->ASCII, 『』->", 【】 stripped,
+//!    ・->space, first －/～ -> ":", ’ -> '.
+//! 2. Whole-title override? -> return it verbatim.
+//! 3. Segment the normalized text into a sequence of:
+//!    - **Override** phrase (matched greedily, may span morphemes) -> verbatim;
+//!    - **Japanese** run (kana/kanji) -> tokenize + romanize;
+//!    - **Passthrough** run (already-Latin letters/digits/punct/space) -> verbatim.
+//! 4. Per Japanese token: word override is handled at the phrase level; particles
+//!    (助詞, listed set) are lowercased with は/へ/を fixed; every other token is the
+//!    romanized reading (or surface if reading is unknown "*"), capitalized.
+//! 5. Join chunks with punctuation-aware single spacing.
+//!
+//! Output is an honest *draft*: morpheme-level segmentation can over-split
+//! compounds and dropped rules #1/#2 leave loanwords (ドラキュラ -> "Dorakyura")
+//! to a human. Overrides absorb the recurring special cases; the note flags the rest.
+
+mod normalize;
+mod overrides;
+pub mod romaji;
+
+use lindera::dictionary::load_dictionary;
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+use lindera::tokenizer::Tokenizer;
+
+use self::overrides::Overrides;
+use super::{Script, TransliterationError, TransliterationOutput, Transliterator};
+
+/// IPADIC `details` index of the katakana reading.
+const READING_INDEX: usize = 7;
+/// IPADIC `details` index of the part-of-speech.
+const POS_INDEX: usize = 0;
+/// IPADIC POS tag for particles.
+const POS_PARTICLE: &str = "助詞";
+
+/// Characters that never take a space *before* them when joining chunks.
+const NO_SPACE_BEFORE: &str = ")]}>:;,.!?\"'-";
+/// Characters that never take a space *after* them when joining chunks.
+const NO_SPACE_AFTER: &str = "([{<\"'";
+
+pub struct JapaneseTransliterator {
+    tokenizer: Tokenizer,
+    overrides: Overrides,
+}
+
+/// A segment of the normalized input.
+enum Segment {
+    /// An override or already-Latin run, emitted verbatim.
+    Verbatim(String),
+    /// A run of kana/kanji to tokenize and romanize.
+    Japanese(String),
+}
+
+impl JapaneseTransliterator {
+    /// Load the embedded IPADIC dictionary and build the tokenizer. This is
+    /// relatively expensive, so construct once and share (see `TransliterationRegistry`).
+    pub fn new() -> Result<Self, TransliterationError> {
+        let dictionary = load_dictionary("embedded://ipadic")
+            .map_err(|e| TransliterationError::Backend(format!("load ipadic: {e}")))?;
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+        let tokenizer = Tokenizer::new(segmenter);
+        Ok(Self {
+            tokenizer,
+            overrides: Overrides::seed(),
+        })
+    }
+
+    /// Romanize one run of Japanese text into capitalized, particle-aware words,
+    /// applying tokenizer-aligned phrase overrides.
+    fn romanize_run(&self, run: &str) -> Result<Vec<String>, TransliterationError> {
+        let mut tokens = self
+            .tokenizer
+            .tokenize(run)
+            .map_err(|e| TransliterationError::Backend(format!("tokenize: {e}")))?;
+
+        // Collect per-token info up front (details() needs &mut self on the token).
+        let mut info: Vec<(String, String, String)> = Vec::with_capacity(tokens.len());
+        for token in tokens.iter_mut() {
+            let surface = token.surface.to_string();
+            let details = token.details();
+            let pos = details.get(POS_INDEX).map(|s| s.as_ref()).unwrap_or("").to_string();
+            let reading = details
+                .get(READING_INDEX)
+                .map(|s| s.as_ref())
+                .unwrap_or("*")
+                .to_string();
+            info.push((surface, pos, reading));
+        }
+        let surfaces: Vec<String> = info.iter().map(|(s, _, _)| s.clone()).collect();
+
+        let mut words = Vec::new();
+        let mut i = 0;
+        while i < info.len() {
+            // Token-aligned phrase override (may span several tokens).
+            if let Some((consumed, val)) = self.overrides.phrase_match(&surfaces, i) {
+                words.push(val.to_string());
+                i += consumed;
+                continue;
+            }
+
+            let (surface, pos, reading) = &info[i];
+
+            // Listed particles (rule #5): は/へ/を fixed, all lowercase.
+            let is_particle = pos == POS_PARTICLE && is_listed_particle(surface);
+            if is_particle {
+                if let Some(p) = particle_romaji(surface) {
+                    words.push(p.to_string());
+                    i += 1;
+                    continue;
+                }
+            }
+
+            let romaji = if reading == "*" || reading.is_empty() {
+                romaji::romanize_kana(surface)
+            } else {
+                romaji::romanize_kana(reading)
+            };
+            let romaji = romaji::expand_macrons(&romaji);
+
+            words.push(if is_particle {
+                romaji
+            } else {
+                capitalize(&romaji)
+            });
+            i += 1;
+        }
+        Ok(words)
+    }
+}
+
+impl Transliterator for JapaneseTransliterator {
+    fn script(&self) -> Script {
+        Script::Japanese
+    }
+
+    fn transliterate(&self, input: &str) -> Result<TransliterationOutput, TransliterationError> {
+        let normalized = normalize::normalize(input.trim());
+
+        // Whole-title override wins outright.
+        if let Some(pinned) = self.overrides.full_lookup(&normalized) {
+            return Ok(TransliterationOutput {
+                text: pinned.to_string(),
+                script: Script::Japanese,
+                notes: Vec::new(),
+            });
+        }
+
+        // Pass A: segment into japanese vs passthrough (already-Latin) runs.
+        // Phrase overrides are applied later, aligned to token boundaries inside
+        // each Japanese run (see `romanize_run`).
+        let mut segments: Vec<Segment> = Vec::new();
+        let mut jp = String::new();
+        let mut pass = String::new();
+        for c in normalized.chars() {
+            if is_japanese(c) {
+                flush(&mut pass, &mut segments, Segment::Verbatim);
+                jp.push(c);
+            } else {
+                flush(&mut jp, &mut segments, Segment::Japanese);
+                pass.push(c);
+            }
+        }
+        flush(&mut pass, &mut segments, Segment::Verbatim);
+        flush(&mut jp, &mut segments, Segment::Japanese);
+
+        // Pass B: render segments into chunks.
+        let mut chunks: Vec<String> = Vec::new();
+        for seg in segments {
+            match seg {
+                Segment::Verbatim(s) => chunks.push(s),
+                Segment::Japanese(s) => {
+                    chunks.extend(self.romanize_run(&s)?);
+                }
+            }
+        }
+
+        let text = capitalize_first_alpha(&join_chunks(&chunks));
+
+        Ok(TransliterationOutput {
+            text,
+            script: Script::Japanese,
+            notes: Vec::new(),
+        })
+    }
+}
+
+/// Move a non-empty accumulator into a new segment built by `make`.
+fn flush(buf: &mut String, segments: &mut Vec<Segment>, make: fn(String) -> Segment) {
+    if !buf.is_empty() {
+        segments.push(make(std::mem::take(buf)));
+    }
+}
+
+fn is_japanese(c: char) -> bool {
+    let u = c as u32;
+    matches!(
+        u,
+        0x3040..=0x30FF   // hiragana + katakana (incl. chouonpu ー)
+            | 0x31F0..=0x31FF // katakana phonetic extensions
+            | 0x3400..=0x4DBF // CJK ext. A
+            | 0x4E00..=0x9FFF // CJK unified ideographs
+    )
+}
+
+/// The exact particle surfaces the framework enumerates for rule #5. We only
+/// lowercase these (not every 助詞 token), so words like でも stay capitalized.
+fn is_listed_particle(surface: &str) -> bool {
+    matches!(
+        surface,
+        "は" | "が"
+            | "を"
+            | "へ"
+            | "か"
+            | "の"
+            | "な"
+            | "も"
+            | "で"
+            | "に"
+            | "と"
+            | "や"
+            | "から"
+            | "まで"
+    )
+}
+
+/// Fixed particle romanizations where the reading differs from the spelling
+/// (rule #5): は -> wa, へ -> e, を -> o. Other listed particles fall through to
+/// normal (lowercased) romanization of their reading.
+fn particle_romaji(surface: &str) -> Option<&'static str> {
+    match surface {
+        "は" => Some("wa"),
+        "へ" => Some("e"),
+        "を" => Some("o"),
+        _ => None,
+    }
+}
+
+/// Capitalize the first ASCII letter, leaving the rest untouched. A leading
+/// non-letter (e.g. '-' on a suffix override) is preserved.
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => {
+            let mut out = String::with_capacity(s.len());
+            out.extend(first.to_uppercase());
+            out.push_str(chars.as_str());
+            out
+        }
+        None => String::new(),
+    }
+}
+
+/// Join chunks with punctuation-aware single spacing: a space is inserted
+/// between two chunks unless either side already supplies a boundary (whitespace)
+/// or the punctuation rules forbid it (e.g. no space before ':' or after '"').
+fn join_chunks(chunks: &[String]) -> String {
+    let mut out = String::new();
+    for c in chunks {
+        if c.is_empty() {
+            continue;
+        }
+        if out.is_empty() {
+            out.push_str(c);
+            continue;
+        }
+        let last = out.chars().last().unwrap();
+        let first = c.chars().next().unwrap();
+        let need_space = last != ' '
+            && first != ' '
+            && !NO_SPACE_BEFORE.contains(first)
+            && !NO_SPACE_AFTER.contains(last);
+        if need_space {
+            out.push(' ');
+        }
+        out.push_str(c);
+    }
+    collapse_spaces(out.trim())
+}
+
+/// Uppercase the first alphabetic character of the final title, so a title that
+/// begins with a lowercase connector override (the/of) or a lowercase loanword
+/// still starts capitalized.
+fn capitalize_first_alpha(s: &str) -> String {
+    let mut done = false;
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if !done && ch.is_alphabetic() {
+            out.extend(ch.to_uppercase());
+            done = true;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Collapse runs of spaces into a single space.
+fn collapse_spaces(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if ch == ' ' {
+            if !prev_space {
+                out.push(' ');
+            }
+            prev_space = true;
+        } else {
+            out.push(ch);
+            prev_space = false;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t() -> JapaneseTransliterator {
+        JapaneseTransliterator::new().expect("load ipadic")
+    }
+
+    fn tr(input: &str) -> String {
+        t().transliterate(input).unwrap().text
+    }
+
+    #[test]
+    fn romanizes_basic_titles() {
+        assert_eq!(tr("どこでもいっしょ"), "Doko Demo Issho");
+        assert_eq!(tr("恋愛"), "Ren'ai");
+    }
+
+    #[test]
+    fn phrase_override_spans_tokens() {
+        // 悪魔城 (over-split compound) + ドラキュラ (data-derived loanword) overrides
+        // combine to the curated form.
+        assert_eq!(tr("悪魔城ドラキュラ"), "Akumajou Dracula");
+    }
+
+    #[test]
+    fn official_romanization_override() {
+        assert_eq!(tr("ファミコン"), "Famicom");
+        assert_eq!(tr("ラーメン"), "Ramen");
+    }
+
+    #[test]
+    fn connector_overrides_and_first_letter_capitalized() {
+        // オブ -> "of" (lowercase mid-title), other tokens romanized.
+        assert_eq!(tr("テイルズ・オブ・ファンタジア"), "Tales of Fantajia");
+        // Leading connector still yields a capitalized first letter.
+        assert_eq!(tr("ザ・ワールド"), "The World");
+    }
+
+    #[test]
+    fn normalization_quotes_and_middot() {
+        assert_eq!(tr("『夢』"), "\"Yume\"");
+        assert_eq!(tr("夢・島"), "Yume Shima");
+    }
+
+    #[test]
+    fn normalization_brackets_and_separator() {
+        assert_eq!(tr("【限定】夢"), "Gentei Yume");
+        // Monospace space before a dash -> colon (subtitle style).
+        assert_eq!(tr("夢　－島"), "Yume: Shima");
+        // No monospace space before -> plain space.
+        assert_eq!(tr("夢－島"), "Yume Shima");
+    }
+
+    #[test]
+    fn passthrough_latin_and_digits() {
+        // Fullwidth alnum folded; copied through verbatim.
+        assert_eq!(tr("２Ｄ"), "2D");
+    }
+
+    #[test]
+    fn capitalize_helper() {
+        assert_eq!(capitalize("doko"), "Doko");
+        assert_eq!(capitalize("-ban"), "-ban");
+        assert_eq!(capitalize(""), "");
+    }
+
+    #[test]
+    fn join_punctuation_aware() {
+        assert_eq!(join_chunks(&["Movie".into(), "-ban".into()]), "Movie-ban");
+        assert_eq!(join_chunks(&["Akumajou".into(), ":".into(), "Densetsu".into()]), "Akumajou: Densetsu");
+        assert_eq!(join_chunks(&["\"".into(), "Yume".into(), "\"".into()]), "\"Yume\"");
+    }
+
+    #[test]
+    #[ignore = "bench: cargo test --release ... bench_resources -- --ignored --nocapture"]
+    fn bench_resources() {
+        use std::time::Instant;
+        let t0 = Instant::now();
+        let t = JapaneseTransliterator::new().expect("load");
+        let load_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        let samples = [
+            "悪魔城ドラキュラ",
+            "ファイナルファンタジーⅦ",
+            "テイルズ・オブ・ファンタジア",
+            "ローライダー　～ラウンド・ザ・ワールド～",
+            "どこでもいっしょ",
+        ];
+        let iters = 5000;
+        let t1 = Instant::now();
+        let mut sink = 0usize;
+        for n in 0..iters {
+            let s = samples[n % samples.len()];
+            sink += t.transliterate(s).unwrap().text.len();
+        }
+        let per_call_us = t1.elapsed().as_secs_f64() * 1_000_000.0 / iters as f64;
+        println!("\n== transliteration bench ==");
+        println!("dictionary load: {load_ms:.0} ms (once, at startup)");
+        println!("per call:        {per_call_us:.1} µs  (avg over {iters}, ~mixed titles)");
+        println!("throughput:      {:.0} calls/sec", 1_000_000.0 / per_call_us);
+        println!("(sink {sink})");
+    }
+
+    #[test]
+    #[ignore = "mining: TITLES_TSV=/tmp/jp_pairs.tsv cargo test ... mine_compounds -- --ignored --nocapture"]
+    fn mine_compounds() {
+        let path = std::env::var("TITLES_TSV").unwrap_or_default();
+        if path.is_empty() {
+            return;
+        }
+        let data = std::fs::read_to_string(&path).unwrap();
+        let t = t();
+        let all_kanji = |s: &str| {
+            !s.is_empty()
+                && s.chars()
+                    .all(|c| matches!(c as u32, 0x3400..=0x4DBF | 0x4E00..=0x9FFF))
+        };
+        // surface-pair -> (joined romaji, count of entries where joining matches curated)
+        let mut tally: std::collections::HashMap<String, (String, u32)> =
+            std::collections::HashMap::new();
+        for line in data.lines() {
+            let Some((fg, ti)) = line.split_once('\t') else { continue };
+            let ti_l = ti.to_lowercase();
+            let mut tokens = t.tokenizer.tokenize(fg).unwrap();
+            let info: Vec<(String, String)> = tokens
+                .iter_mut()
+                .map(|tok| {
+                    let s = tok.surface.to_string();
+                    let r = tok
+                        .details()
+                        .get(READING_INDEX)
+                        .map(|x| x.as_ref())
+                        .unwrap_or("*")
+                        .to_string();
+                    (s, r)
+                })
+                .collect();
+            for w in info.windows(2) {
+                let (s1, r1) = &w[0];
+                let (s2, r2) = &w[1];
+                if !all_kanji(s1) || !all_kanji(s2) || r1 == "*" || r2 == "*" {
+                    continue;
+                }
+                let a = romaji::romanize_kana(r1);
+                let b = romaji::romanize_kana(r2);
+                let joined = format!("{a}{b}").to_lowercase();
+                let spaced = format!("{a} {b}").to_lowercase();
+                if joined.len() < 5 {
+                    continue;
+                }
+                if ti_l.contains(&joined) && !ti_l.contains(&spaced) {
+                    let key = format!("{s1}{s2}");
+                    let val = capitalize(&format!("{a}{b}"));
+                    let e = tally.entry(key).or_insert((val, 0));
+                    e.1 += 1;
+                }
+            }
+        }
+        let mut v: Vec<_> = tally.into_iter().collect();
+        v.sort_by(|a, b| b.1 .1.cmp(&a.1 .1));
+        println!("\n== top over-split compounds (surface -> joined, count) ==");
+        for (k, (val, c)) in v.iter().take(40) {
+            println!("  {c:4}  {k}  ->  {val}");
+        }
+    }
+
+    #[test]
+    #[ignore = "analysis: TITLES_TSV=/tmp/jp_pairs.tsv cargo test ... -- --ignored --nocapture"]
+    fn analyze_dataset() {
+        let path = std::env::var("TITLES_TSV").unwrap_or_default();
+        if path.is_empty() {
+            eprintln!("set TITLES_TSV to run");
+            return;
+        }
+        let data = std::fs::read_to_string(&path).unwrap();
+        let t = t();
+        let (mut n, mut exact, mut ci_exact) = (0u64, 0u64, 0u64);
+        // Subset with NO katakana loanwords -- titles the engine is fully
+        // responsible for (case-insensitive match).
+        let (mut n_nk, mut ci_nk, mut sp_nk) = (0u64, 0u64, 0u64);
+        let mut sp_all = 0u64; // space+case-insensitive match (romanization correct, spacing aside)
+        let has_katakana = |s: &str| s.chars().any(|c| matches!(c as u32, 0x30A1..=0x30FA));
+        let squash = |s: &str| s.to_lowercase().replace([' ', '-', ':'], "");
+        let mut mismatches: Vec<(String, String, String)> = Vec::new();
+        for line in data.lines() {
+            let Some((fg, ti)) = line.split_once('\t') else { continue };
+            let Ok(out) = t.transliterate(fg) else { continue };
+            n += 1;
+            let ci = out.text.to_lowercase() == ti.to_lowercase();
+            if out.text == ti {
+                exact += 1;
+            } else if ci {
+                ci_exact += 1;
+            } else if mismatches.len() < 25 {
+                mismatches.push((fg.to_string(), out.text.clone(), ti.to_string()));
+            }
+            let sp = squash(&out.text) == squash(ti);
+            if sp {
+                sp_all += 1;
+            }
+            if !has_katakana(fg) {
+                n_nk += 1;
+                if ci {
+                    ci_nk += 1;
+                }
+                if sp {
+                    sp_nk += 1;
+                }
+            }
+        }
+        println!("\n== {n} entries ==");
+        println!("exact match:           {exact}  ({:.1}%)", 100.0 * exact as f64 / n as f64);
+        println!("case-insensitive match:{ci_exact}  ({:.1}%)", 100.0 * ci_exact as f64 / n as f64);
+        println!("combined:              {}  ({:.1}%)", exact + ci_exact, 100.0 * (exact + ci_exact) as f64 / n as f64);
+        println!(
+            "no-katakana subset:    {ci_nk}/{n_nk}  ({:.1}%)  [kanji/kana-only titles]",
+            100.0 * ci_nk as f64 / n_nk as f64
+        );
+        println!(
+            "romanization-correct (ignoring spacing/case): all {:.1}%, no-katakana {:.1}%",
+            100.0 * sp_all as f64 / n as f64,
+            100.0 * sp_nk as f64 / n_nk as f64
+        );
+        println!("\n-- sample mismatches (foreign | engine | curated) --");
+        for (fg, eng, ti) in mismatches.iter().take(20) {
+            println!("  {fg}\n    engine : {eng}\n    curated: {ti}");
+        }
+    }
+
+    #[test]
+    #[ignore = "demo: run with --ignored --nocapture to see real output"]
+    fn demo_pdf_examples() {
+        let t = t();
+        for s in [
+            "どこでもいっしょ",
+            "悪魔城ドラキュラ",
+            "恋愛",
+            "列車",
+            "四つ",
+            "抹茶",
+            "千葉県",
+            "ガーン",
+            "ファミコン",
+            "ラーメン",
+            "『夢』・島",
+            "ＲＰＧ ２",
+            "悪魔城ドラキュラ　Ｘ～月下の夜想曲～　オリジナル・ゲーム・サントラ",
+        ] {
+            let out = t.transliterate(s).unwrap();
+            println!("{s}  ->  {}", out.text);
+        }
+    }
+}

--- a/src/transliteration/japanese/normalize.rs
+++ b/src/transliteration/japanese/normalize.rs
@@ -1,0 +1,290 @@
+//! Input normalization applied to a Foreign Title before tokenization.
+//!
+//! These rules clean up characters that commonly appear in Japanese titles so
+//! the result is a sensible Latin-script Main Title:
+//!
+//! - Fullwidth ASCII (letters, digits, punctuation) and the ideographic space
+//!   are folded to their normal ASCII forms ("２Ｄ" -> "2D", "　" -> " ").
+//! - ’ (U+2019) -> ' (ASCII apostrophe).
+//! - Japanese quotation marks 『 』 -> western double quote ".
+//! - 【 】 and 「 」 are stripped (ignored).
+//! - Unicode Roman numerals Ⅰ..Ⅻ (and L/C/D/M) -> ASCII letters (Ⅶ -> "VII").
+//! - ・ (katakana middle dot) -> a space.
+//! - Separator dashes/tildes （－ ～ 〜） are resolved against the *monospace*
+//!   space 　 (U+3000) around them:
+//!     - `　-` / `　～` (monospace space before)  -> ": " (colon + space);
+//!     - a separator with no monospace space before -> " " (a plain space);
+//!     - `-　` / `～　` (monospace space after, none before) -> removed.
+//!   For the wrapped form `　-　`, the "before" rule wins and the trailing
+//!   monospace space is absorbed, giving ": ". Only the fullwidth/wave separator
+//!   forms are treated this way -- an ASCII '-' (e.g. "Spider-Man") is preserved.
+//!
+//! The katakana chouonpu ー (U+30FC) is intentionally left untouched -- it is a
+//! long-vowel marker handled later by the romaji rules, not a separator.
+
+/// Monospace (ideographic / fullwidth) space.
+const MONOSPACE_SPACE: char = '\u{3000}';
+
+/// Title separator dashes/tildes: fullwidth hyphen-minus －, wave dash 〜, and
+/// fullwidth tilde ～. ASCII '-'/'~' are deliberately excluded.
+fn is_separator(c: char) -> bool {
+    matches!(c, '\u{FF0D}' | '\u{301C}' | '\u{FF5E}')
+}
+
+/// Unicode Roman numeral character -> ASCII letters. Covers the common uppercase
+/// forms Ⅰ..Ⅻ plus L/C/D/M. Lowercase forms (often used as "x"/multiplication)
+/// are intentionally left alone.
+fn roman_numeral(c: char) -> Option<&'static str> {
+    Some(match c {
+        '\u{2160}' => "I",
+        '\u{2161}' => "II",
+        '\u{2162}' => "III",
+        '\u{2163}' => "IV",
+        '\u{2164}' => "V",
+        '\u{2165}' => "VI",
+        '\u{2166}' => "VII",
+        '\u{2167}' => "VIII",
+        '\u{2168}' => "IX",
+        '\u{2169}' => "X",
+        '\u{216A}' => "XI",
+        '\u{216B}' => "XII",
+        '\u{216C}' => "L",
+        '\u{216D}' => "C",
+        '\u{216E}' => "D",
+        '\u{216F}' => "M",
+        _ => return None,
+    })
+}
+
+/// Katakana spelling of a single Latin letter (エー -> "A", エックス -> "X").
+fn letter_name(s: &str) -> Option<&'static str> {
+    Some(match s {
+        "エー" => "A",
+        "ビー" => "B",
+        "シー" => "C",
+        "ディー" => "D",
+        "イー" => "E",
+        "エフ" => "F",
+        "ジー" => "G",
+        "エイチ" => "H",
+        "アイ" => "I",
+        "ジェー" | "ジェイ" => "J",
+        "ケー" => "K",
+        "エル" => "L",
+        "エム" => "M",
+        "エヌ" => "N",
+        "オー" => "O",
+        "ピー" => "P",
+        "キュー" => "Q",
+        "アール" => "R",
+        "エス" => "S",
+        "ティー" => "T",
+        "ユー" => "U",
+        "ブイ" => "V",
+        "ダブリュー" => "W",
+        "エックス" => "X",
+        "ワイ" => "Y",
+        "ゼット" | "ズィー" => "Z",
+        _ => return None,
+    })
+}
+
+/// Collapse `・`-delimited sequences of katakana letter-names (length >= 2) into
+/// the concatenated Latin acronym (ディー・エックス -> "DX"). Sequences that are not
+/// entirely letter-names are left untouched for normal handling. Rare in the
+/// dataset but unambiguous when the `・` delimiter is present.
+fn despell_letters(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    // Split into `・`-delimited groups but keep other text intact: scan runs.
+    for segment in split_keep_non_dot_groups(input) {
+        let parts: Vec<&str> = segment.split('・').collect();
+        if parts.len() >= 2 && parts.iter().all(|p| letter_name(p).is_some()) {
+            for p in parts {
+                out.push_str(letter_name(p).unwrap());
+            }
+        } else {
+            out.push_str(segment);
+        }
+    }
+    out
+}
+
+/// Split `input` into maximal segments that are either a single `・`-joined run of
+/// katakana, or any other text, preserving order and content.
+fn split_keep_non_dot_groups(input: &str) -> Vec<&str> {
+    let bytes: Vec<(usize, char)> = input.char_indices().collect();
+    let is_kata = |c: char| {
+        matches!(c as u32, 0x30A1..=0x30FA | 0x30FC..=0x30FF) // katakana letters, excludes ・(30FB)
+    };
+    let mut segs = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Try to grow a katakana(・katakana)+ group from i.
+        let start = bytes[i].0;
+        let mut j = i;
+        let mut saw_group = false;
+        loop {
+            let run_start = j;
+            while j < bytes.len() && is_kata(bytes[j].1) {
+                j += 1;
+            }
+            if j == run_start {
+                break;
+            }
+            // optional ・ followed by more katakana
+            if j < bytes.len()
+                && bytes[j].1 == '・'
+                && j + 1 < bytes.len()
+                && is_kata(bytes[j + 1].1)
+            {
+                saw_group = true;
+                j += 1;
+                continue;
+            }
+            break;
+        }
+        if saw_group {
+            let end = if j < bytes.len() { bytes[j].0 } else { input.len() };
+            segs.push(&input[start..end]);
+            i = j;
+        } else {
+            // Emit a single char as its own segment.
+            let end = if i + 1 < bytes.len() {
+                bytes[i + 1].0
+            } else {
+                input.len()
+            };
+            segs.push(&input[start..end]);
+            i += 1;
+        }
+    }
+    segs
+}
+
+/// Normalize a raw Foreign Title string per the rules above.
+pub fn normalize(input: &str) -> String {
+    let despelled = despell_letters(input);
+    let chars: Vec<char> = despelled.chars().collect();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if is_separator(c) {
+            let before_mono = i > 0 && chars[i - 1] == MONOSPACE_SPACE;
+            let after_mono = i + 1 < chars.len() && chars[i + 1] == MONOSPACE_SPACE;
+
+            if before_mono {
+                // "　-" / "　-　" -> ": " (drop the space(s) we already emitted
+                // for the leading monospace space, absorb a trailing one).
+                while out.ends_with(' ') {
+                    out.pop();
+                }
+                out.push_str(": ");
+                if after_mono {
+                    i += 1; // absorb trailing monospace space
+                }
+            } else if after_mono {
+                // "-　" -> removed (drop the separator and the trailing space).
+                i += 1; // absorb trailing monospace space
+            } else {
+                // bare separator -> a plain space
+                out.push(' ');
+            }
+            i += 1;
+            continue;
+        }
+
+        match c {
+            '\u{3000}' => out.push(' '),                  // ideographic (fullwidth) space
+            '\u{2019}' => out.push('\''),                 // ’ -> '
+            '\u{300E}' | '\u{300F}' => out.push('"'),     // 『 』 -> "
+            '\u{3010}' | '\u{3011}' => {}                 // 【 】 -> ignore (strip)
+            '\u{300C}' | '\u{300D}' => {}                 // 「 」 -> ignore (strip)
+            '\u{30FB}' => out.push(' '),                  // ・ -> space
+            // Unicode Roman numerals -> ASCII letters (Ⅶ -> "VII").
+            c if roman_numeral(c).is_some() => out.push_str(roman_numeral(c).unwrap()),
+            // Fullwidth ASCII block U+FF01..=U+FF5E -> ASCII (subtract 0xFEE0).
+            c if ('\u{FF01}'..='\u{FF5E}').contains(&c) => {
+                out.push(char::from_u32(c as u32 - 0xFEE0).unwrap_or(c));
+            }
+            _ => out.push(c),
+        }
+        i += 1;
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folds_fullwidth_alnum_and_space() {
+        assert_eq!(normalize("２Ｄ"), "2D");
+        assert_eq!(normalize("ＲＰＧ"), "RPG");
+        assert_eq!(normalize("Ａ　Ｂ"), "A B");
+        assert_eq!(normalize("２０２４"), "2024");
+    }
+
+    #[test]
+    fn apostrophe_and_quotes() {
+        assert_eq!(normalize("d’s"), "d's");
+        assert_eq!(normalize("『夢』"), "\"夢\"");
+    }
+
+    #[test]
+    fn brackets_stripped_and_middot_spaced() {
+        assert_eq!(normalize("【限定】夢"), "限定夢");
+        assert_eq!(normalize("「夢」島"), "夢島");
+        assert_eq!(normalize("夢・島"), "夢 島");
+    }
+
+    #[test]
+    fn separator_monospace_before_becomes_colon() {
+        assert_eq!(normalize("夢　－島"), "夢: 島");
+        assert_eq!(normalize("夢　～島"), "夢: 島");
+        assert_eq!(normalize("夢　〜島"), "夢: 島");
+        // Wrapped form 　-　 : "before" wins, trailing monospace space absorbed.
+        assert_eq!(normalize("夢　－　島"), "夢: 島");
+    }
+
+    #[test]
+    fn separator_without_monospace_before_becomes_space() {
+        assert_eq!(normalize("夢－島"), "夢 島");
+        assert_eq!(normalize("夢～島"), "夢 島");
+    }
+
+    #[test]
+    fn separator_with_trailing_monospace_is_removed() {
+        assert_eq!(normalize("夢－　島"), "夢島");
+        assert_eq!(normalize("夢～　島"), "夢島");
+    }
+
+    #[test]
+    fn ascii_hyphen_is_preserved() {
+        assert_eq!(normalize("Spider-Man"), "Spider-Man");
+    }
+
+    #[test]
+    fn chouonpu_preserved() {
+        assert_eq!(normalize("ラーメン"), "ラーメン");
+    }
+
+    #[test]
+    fn roman_numerals_to_ascii() {
+        assert_eq!(normalize("幻想水滸伝Ⅱ"), "幻想水滸伝II");
+        assert_eq!(normalize("ファイナルファンタジーⅦ"), "ファイナルファンタジーVII");
+        assert_eq!(normalize("三國志Ⅲ"), "三國志III");
+    }
+
+    #[test]
+    fn letter_spelling_via_dot() {
+        assert_eq!(normalize("雷電ディー・エックス"), "雷電DX");
+        assert_eq!(normalize("エル・オー・エル"), "LOL");
+        // A non-letter-name group keeps the middot -> space behavior.
+        assert_eq!(normalize("ラウンド・ザ・ワールド"), "ラウンド ザ ワールド");
+    }
+}

--- a/src/transliteration/japanese/normalize.rs
+++ b/src/transliteration/japanese/normalize.rs
@@ -203,6 +203,10 @@ pub fn normalize(input: &str) -> String {
             '\u{3010}' | '\u{3011}' => {}                 // 【 】 -> ignore (strip)
             '\u{300C}' | '\u{300D}' => {}                 // 「 」 -> ignore (strip)
             '\u{30FB}' => out.push(' '),                  // ・ -> space
+            '\u{3001}' => out.push(','),                  // 、 -> ,
+            '\u{3002}' => out.push('.'),                  // 。 -> .
+            // Stray (semi)voiced sound marks used decoratively -> strip.
+            '\u{309B}' | '\u{309C}' | '\u{3099}' | '\u{309A}' => {}
             // Unicode Roman numerals -> ASCII letters (Ⅶ -> "VII").
             c if roman_numeral(c).is_some() => out.push_str(roman_numeral(c).unwrap()),
             // Fullwidth ASCII block U+FF01..=U+FF5E -> ASCII (subtract 0xFEE0).
@@ -271,6 +275,12 @@ mod tests {
     #[test]
     fn chouonpu_preserved() {
         assert_eq!(normalize("ラーメン"), "ラーメン");
+    }
+
+    #[test]
+    fn ideographic_comma_and_period() {
+        assert_eq!(normalize("武将、城"), "武将,城");
+        assert_eq!(normalize("終わり。"), "終わり.");
     }
 
     #[test]

--- a/src/transliteration/japanese/overrides.rs
+++ b/src/transliteration/japanese/overrides.rs
@@ -1,0 +1,220 @@
+//! Curated overrides for Japanese transliteration.
+//!
+//! The general engine (lindera readings + `romaji` rules) handles the bulk of
+//! titles phonetically. Overrides capture cases that are *judgment*, not
+//! mechanics, and so cannot be derived algorithmically.
+//!
+//! ## Matching model: tokenizer-aligned
+//!
+//! Phrase overrides match against lindera **token boundaries**, not raw
+//! substrings. A key is the concatenation of one or more consecutive token
+//! *surfaces*; it only fires when it lines up with whole tokens. This avoids the
+//! substring trap -- an override for スター ("Star") never matches inside the
+//! single token モンスター ("Monster") -- while still letting a multi-token
+//! compound like 悪魔城 (tokenized 悪魔 + 城) be pinned to "Akumajou".
+//!
+//! ## Granularities
+//! - `full`   : exact whole-input (normalized) match -> exact output. Highest priority.
+//! - `phrase` : a token-surface sequence -> a fixed output fragment, matched
+//!              greedily (longest token run first).
+//!
+//! A leading '-' on a phrase output attaches it to the previous word without a
+//! space (e.g. a "-ban" suffix -> "Movie-ban").
+//!
+//! Only **unambiguous** entries belong here. Ambiguous loanwords (ロード =
+//! Lord/Road/Load, フォー = Four/for) are deliberately left to mechanical
+//! romanization + manual edit. Titles whose official English is printed on the
+//! item (e.g. バイオハザード) are also left manual.
+
+use std::collections::HashMap;
+
+/// Maximum number of consecutive tokens a phrase override may span.
+const MAX_PHRASE_TOKENS: usize = 8;
+
+pub struct Overrides {
+    full: HashMap<String, String>,
+    phrase: HashMap<String, String>,
+}
+
+impl Overrides {
+    /// Build the seed override set.
+    pub fn seed() -> Self {
+        let mut full: HashMap<String, String> = HashMap::new();
+        let mut phrase: HashMap<String, String> = HashMap::new();
+
+        // --- Whole-title pins (normalized input -> Main Title) ---
+        // (none yet; add titles that need exact, hand-verified output)
+        let _ = &mut full;
+
+        for (k, v) in PHRASE_SEED {
+            phrase.insert(k.to_string(), v.to_string());
+        }
+
+        Self { full, phrase }
+    }
+
+    /// Exact whole-input override (input should already be normalized).
+    pub fn full_lookup(&self, input: &str) -> Option<&str> {
+        self.full.get(input.trim()).map(|s| s.as_str())
+    }
+
+    /// Longest token-aligned phrase override starting at `start` in `surfaces`.
+    /// Returns the number of tokens consumed and the replacement output.
+    pub fn phrase_match(&self, surfaces: &[String], start: usize) -> Option<(usize, &str)> {
+        let max = MAX_PHRASE_TOKENS.min(surfaces.len() - start);
+        for k in (1..=max).rev() {
+            let candidate: String = surfaces[start..start + k].concat();
+            if let Some(v) = self.phrase.get(&candidate) {
+                return Some((k, v.as_str()));
+            }
+        }
+        None
+    }
+}
+
+/// Seed phrase overrides (token-surface -> output). Grouped by theme; grown from
+/// real dataset analysis. Keep entries unambiguous.
+const PHRASE_SEED: &[(&str, &str)] = &[
+    // --- Official romanizations that deviate from strict Hepburn ---
+    ("ファミコン", "Famicom"),
+    ("ラーメン", "Ramen"),
+    ("ファミ通", "Famitsu"),
+    // --- Multi-token kanji compounds that segmentation over-splits ---
+    ("悪魔城", "Akumajou"),
+    // --- Common loanword nouns (frequency in the 31k-entry dataset in
+    //     parentheses; all verified unambiguous against real titles) ---
+    ("シリーズ", "Series"),        // 709
+    ("サウンドトラック", "Soundtrack"), // 527
+    ("サントラ", "Soundtrack"),     // 45 (abbreviation of サウンドトラック)
+    ("オリジナル", "Original"),     // 473
+    ("ゲーム", "Game"),            // 335
+    ("コレクション", "Collection"), // 231
+    ("サウンド", "Sound"),         // 223
+    ("スペシャル", "Special"),      // 204
+    ("ミュージック", "Music"),      // 171
+    ("ワールド", "World"),         // 162
+    ("ポータブル", "Portable"),     // 146
+    ("スーパー", "Super"),         // 123
+    ("キング", "King"),            // 103
+    ("アーケード", "Arcade"),       // 96
+    ("テイルズ", "Tales"),         // 94
+    ("オンライン", "Online"),       // 87
+    ("デジタル", "Digital"),        // 87
+    ("ウォーズ", "Wars"),          // 74
+    ("スター", "Star"),            // 72
+    ("コール", "Call"),            // 66
+    ("デッド", "Dead"),            // 64
+    ("ベスト", "Best"),            // 37
+    // --- Structural connectors (lowercase; the final title's first letter is
+    //     re-capitalized downstream so a leading connector still looks right) ---
+    ("オブ", "of"),               // 766
+    ("ザ", "the"),                // 818
+    ("アンド", "and"),             // 39
+    // --- Platforms / companies ---
+    ("プレイステーション", "PlayStation"), // 216
+    ("マイクロソフト", "Microsoft"),    // 66
+    // --- Kanji compounds the tokenizer over-splits (mined + verified against the
+    //     dataset: count = curated titles using the joined form). These are joined,
+    //     never hyphenated -- matching the framework's non-hyphenated suffix cases
+    //     (限定版 -> Genteiban, 恋姫 -> Koihime). ---
+    ("限定版", "Genteiban"),     // 112
+    ("錬金術士", "Renkinjutsushi"), // 78
+    ("大戦略", "Daisenryaku"),   // 58
+    ("大作戦", "Daisakusen"),    // 57
+    ("大冒険", "Daibouken"),     // 52
+    ("必勝法", "Hisshouhou"),    // 52
+    ("王子様", "Oujisama"),      // 47
+    ("完全版", "Kanzenban"),     // 46
+    ("体験版", "Taikenban"),     // 43
+    ("大航海", "Daikoukai"),     // 34
+    ("奇譚", "Kitan"),           // 33
+    ("将伝", "Shouden"),         // 33
+    ("猛将", "Moushou"),         // 33
+    ("決定版", "Ketteiban"),     // 29
+    ("大全集", "Daizenshuu"),    // 28
+    ("山佐", "Yamasa"),          // 27
+    ("鬼武者", "Onimusha"),      // 23
+    ("異聞録", "Ibunroku"),      // 23
+    ("事件簿", "Jikenbo"),       // 22
+    ("錬金術師", "Renkinjutsushi"), // 21
+    ("疾風伝", "Shippuuden"),    // 20
+    ("魔人", "Majin"),           // 20
+    ("名探偵", "Meitantei"),     // 19
+    ("神伝", "Shinden"),         // 19
+    ("機神", "Kishin"),          // 18
+    ("第二", "Daini"),           // 16
+    ("恋姫", "Koihime"),         // 16
+    ("大乱闘", "Dairantou"),     // 16
+    ("戦極", "Sengoku"),         // 16
+    ("豪華版", "Goukaban"),      // 15
+    ("原画集", "Gengashuu"),     // 15
+    ("総選挙", "Sousenkyo"),     // 14
+    ("虫姫", "Mushihime"),       // 13
+    ("魔装", "Masou"),           // 13
+    // --- Recurring loanwords / franchise names. Both the katakana key and the
+    //     English value are DATA-DERIVED: mined by statistical association with the
+    //     curated English titles and hand-verified (count in parens). Spurious
+    //     co-occurrences, fragments, and titles with varying printed English
+    //     (バイオハザード) were excluded. ---
+    ("ファイナルファンタジー", "Final Fantasy"), // 223
+    ("ドラマ", "Drama"),         // 254
+    ("ガンダム", "Gundam"),       // 171
+    ("サクラ", "Sakura"),         // 135
+    ("プロモーション", "Promotion"), // 133
+    ("イース", "Ys"),             // 110
+    ("アトリエ", "Atelier"),       // 97
+    ("メモリアル", "Memorial"),    // 88
+    ("パワフルプロ", "Powerful Pro"), // 86
+    ("ウイニングポスト", "Winning Post"), // 83
+    ("ウイニングイレブン", "Winning Eleven"), // 82
+    ("プリンセス", "Princess"),    // 79
+    ("ドラキュラ", "Dracula"),     // 79
+    ("ファンタシースターオンライン", "Phantasy Star Online"), // 66
+    ("ソニック", "Sonic"),         // 66
+    ("ゼルダ", "Zelda"),          // 65
+    ("ロックマン", "Rockman"),     // 64
+    ("テニス", "Tennis"),         // 66
+    ("ドラゴンクエスト", "Dragon Quest"), // 71
+    ("アルティメット", "Ultimate"), // 71
+    ("ディアボリックラヴァーズ", "Diabolik Lovers"), // 70
+    ("クイズ", "Quiz"),           // 67
+    ("デモ", "Demo"),             // 70
+    ("ダンジョン", "Dungeon"),     // 56
+    ("アンジェリーク", "Angelique"), // 58
+    ("エヴァンゲリオン", "Evangelion"), // 58
+    ("パチスロ", "Pachi-Slot"),    // 154
+    ("パワーアップキット", "Power-Up Kit"), // 87
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn surfaces(words: &[&str]) -> Vec<String> {
+        words.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn matches_single_token() {
+        let o = Overrides::seed();
+        let s = surfaces(&["ファミコン", "ソフト"]);
+        assert_eq!(o.phrase_match(&s, 0), Some((1, "Famicom")));
+    }
+
+    #[test]
+    fn matches_multi_token_compound() {
+        let o = Overrides::seed();
+        // 悪魔城 tokenized as 悪魔 + 城 -> 2 tokens consumed.
+        let s = surfaces(&["悪魔", "城", "ドラキュラ"]);
+        assert_eq!(o.phrase_match(&s, 0), Some((2, "Akumajou")));
+    }
+
+    #[test]
+    fn does_not_match_inside_a_token() {
+        let o = Overrides::seed();
+        // A hypothetical スター override must not fire inside モンスター; here we
+        // confirm a non-seeded single token simply misses.
+        let s = surfaces(&["モンスター"]);
+        assert_eq!(o.phrase_match(&s, 0), None);
+    }
+}

--- a/src/transliteration/japanese/overrides.rs
+++ b/src/transliteration/japanese/overrides.rs
@@ -151,6 +151,10 @@ const PHRASE_SEED: &[(&str, &str)] = &[
     ("総選挙", "Sousenkyo"),     // 14
     ("虫姫", "Mushihime"),       // 13
     ("魔装", "Masou"),           // 13
+    ("水滸伝", "Suikoden"),      // Suikoden; 滸 has no IPADIC reading
+    ("弐", "Ni"),                // sequel marker (二); no IPADIC reading
+    ("三國志", "Sangokushi"),    // 160 titles (traditional 國); read wrong otherwise
+    ("三国志", "Sangokushi"),    // 44 titles (modern 国)
     // --- Recurring loanwords / franchise names. Both the katakana key and the
     //     English value are DATA-DERIVED: mined by statistical association with the
     //     curated English titles and hand-verified (count in parens). Spurious
@@ -181,6 +185,9 @@ const PHRASE_SEED: &[(&str, &str)] = &[
     ("デモ", "Demo"),             // 70
     ("ダンジョン", "Dungeon"),     // 56
     ("アンジェリーク", "Angelique"), // 58
+    ("アンジェリ", "Angelique"),   // requested; longest-match keeps アンジェリーク intact
+    ("エンジェル", "Angel"),       // 24 (エンジェル = Angel)
+    ("エンゼル", "Angel"),         // 3 (older transliteration of Angel)
     ("エヴァンゲリオン", "Evangelion"), // 58
     ("パチスロ", "Pachi-Slot"),    // 154
     ("パワーアップキット", "Power-Up Kit"), // 87

--- a/src/transliteration/japanese/romaji.rs
+++ b/src/transliteration/japanese/romaji.rs
@@ -1,0 +1,359 @@
+//! Pure kana -> romaji conversion (modified Hepburn, title style).
+//!
+//! This module has **no external dependencies** and is fully unit-tested. It
+//! operates on a kana string (hiragana or katakana) -- typically the katakana
+//! *reading* of a token produced by the tokenizer, or a kana surface form.
+//!
+//! It implements the mechanical rules from the Redump title framework:
+//! - base syllable table + palatalized (きゃ -> kya) + common foreign (ファ -> fa) combos
+//! - sokuon っ/ッ gemination, including the っち -> "tch" exception
+//! - chouonpu ー long-vowel repetition (ガーン -> Gaan)
+//! - ん/ン -> "n", written "n'" before a vowel or "y" (れんあい -> ren'ai)
+//!
+//! Word spacing, capitalization, particle handling and overrides live one level
+//! up in `japanese::mod`, because they need token/POS context this layer lacks.
+//! Non-kana characters (latin, digits, punctuation) pass through unchanged.
+
+/// One logical kana element, produced in pass 1 and assembled in pass 2.
+enum Unit {
+    /// A romanized syllable (already lowercase romaji).
+    Syl(String),
+    /// Sokuon っ/ッ -- geminate the following consonant.
+    Sokuon,
+    /// Chouonpu ー -- repeat the preceding vowel.
+    Choon,
+    /// Moraic nasal ん/ン.
+    N,
+    /// Passthrough text that is not kana (latin, digits, symbols).
+    Raw(String),
+}
+
+/// Convert a kana string to romaji, applying the mechanical Hepburn rules.
+pub fn romanize_kana(input: &str) -> String {
+    let kata: Vec<char> = to_katakana(input).chars().collect();
+    let units = lex(&kata);
+    assemble(&units)
+}
+
+/// Expand Latin vowels carrying macrons into the title-style double-vowel form
+/// (rule #4): ā->aa, ē->ee, ī->ii, ō->ou, ū->uu (case preserving). Useful when an
+/// override or surface form already contains macrons.
+pub fn expand_macrons(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            'ā' => out.push_str("aa"),
+            'ē' => out.push_str("ee"),
+            'ī' => out.push_str("ii"),
+            'ō' => out.push_str("ou"),
+            'ū' => out.push_str("uu"),
+            'Ā' => out.push_str("Aa"),
+            'Ē' => out.push_str("Ee"),
+            'Ī' => out.push_str("Ii"),
+            'Ō' => out.push_str("Ou"),
+            'Ū' => out.push_str("Uu"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Normalize hiragana to katakana so we only maintain one table. Small kana,
+/// chouonpu and non-kana are left as-is.
+fn to_katakana(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            let u = c as u32;
+            // Hiragana block U+3041..=U+3096 -> Katakana by +0x60.
+            if (0x3041..=0x3096).contains(&u) {
+                char::from_u32(u + 0x60).unwrap_or(c)
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+fn is_vowel(c: char) -> bool {
+    matches!(c, 'a' | 'e' | 'i' | 'o' | 'u')
+}
+
+/// Small vowel kana -> its plain vowel romaji.
+fn small_vowel(c: char) -> Option<char> {
+    match c {
+        'ァ' => Some('a'),
+        'ィ' => Some('i'),
+        'ゥ' => Some('u'),
+        'ェ' => Some('e'),
+        'ォ' => Some('o'),
+        _ => None,
+    }
+}
+
+fn small_ya(c: char) -> Option<char> {
+    match c {
+        'ャ' => Some('a'),
+        'ュ' => Some('u'),
+        'ョ' => Some('o'),
+        _ => None,
+    }
+}
+
+/// Base katakana syllable -> romaji.
+fn kata_base(c: char) -> Option<&'static str> {
+    let s = match c {
+        'ア' => "a", 'イ' => "i", 'ウ' => "u", 'エ' => "e", 'オ' => "o",
+        'カ' => "ka", 'キ' => "ki", 'ク' => "ku", 'ケ' => "ke", 'コ' => "ko",
+        'ガ' => "ga", 'ギ' => "gi", 'グ' => "gu", 'ゲ' => "ge", 'ゴ' => "go",
+        'サ' => "sa", 'シ' => "shi", 'ス' => "su", 'セ' => "se", 'ソ' => "so",
+        'ザ' => "za", 'ジ' => "ji", 'ズ' => "zu", 'ゼ' => "ze", 'ゾ' => "zo",
+        'タ' => "ta", 'チ' => "chi", 'ツ' => "tsu", 'テ' => "te", 'ト' => "to",
+        'ダ' => "da", 'ヂ' => "ji", 'ヅ' => "zu", 'デ' => "de", 'ド' => "do",
+        'ナ' => "na", 'ニ' => "ni", 'ヌ' => "nu", 'ネ' => "ne", 'ノ' => "no",
+        'ハ' => "ha", 'ヒ' => "hi", 'フ' => "fu", 'ヘ' => "he", 'ホ' => "ho",
+        'バ' => "ba", 'ビ' => "bi", 'ブ' => "bu", 'ベ' => "be", 'ボ' => "bo",
+        'パ' => "pa", 'ピ' => "pi", 'プ' => "pu", 'ペ' => "pe", 'ポ' => "po",
+        'マ' => "ma", 'ミ' => "mi", 'ム' => "mu", 'メ' => "me", 'モ' => "mo",
+        'ヤ' => "ya", 'ユ' => "yu", 'ヨ' => "yo",
+        'ラ' => "ra", 'リ' => "ri", 'ル' => "ru", 'レ' => "re", 'ロ' => "ro",
+        'ワ' => "wa", 'ヰ' => "wi", 'ヱ' => "we", 'ヲ' => "o",
+        'ヴ' => "vu",
+        _ => return None,
+    };
+    Some(s)
+}
+
+/// Combine an "i"-row base (ki, shi, chi, ji, ni, hi, mi, ri, gi, bi, pi) with a
+/// small ya/yu/yo glide: きゃ -> kya, しゃ -> sha, ちゃ -> cha, じゃ -> ja.
+fn palatalize(base: &str, glide_vowel: char) -> Option<String> {
+    if !base.ends_with('i') {
+        return None;
+    }
+    let r = match base {
+        "shi" => format!("sh{glide_vowel}"),
+        "chi" => format!("ch{glide_vowel}"),
+        "ji" => format!("j{glide_vowel}"),
+        // ki -> ky, ni -> ny, hi -> hy, mi -> my, ri -> ry, gi -> gy, bi -> by, pi -> py
+        _ => format!("{}y{glide_vowel}", &base[..base.len() - 1]),
+    };
+    Some(r)
+}
+
+/// Common foreign-sound combos: base + small vowel (ファ -> fa, ティ -> ti, ウィ -> wi).
+fn foreign_combo(base_char: char, small: char) -> Option<String> {
+    let v = small_vowel(small)?;
+    let r = match base_char {
+        'フ' => format!("f{v}"),       // ファ fa, フィ fi, フェ fe, フォ fo
+        'ヴ' => format!("v{v}"),       // ヴァ va ...
+        'ウ' => format!("w{v}"),       // ウィ wi, ウェ we, ウォ wo, ウァ wa
+        'ツ' => format!("ts{v}"),      // ツァ tsa ...
+        'テ' if v == 'i' => "ti".to_string(),
+        'デ' if v == 'i' => "di".to_string(),
+        'ト' if v == 'u' => "tu".to_string(),
+        'ド' if v == 'u' => "du".to_string(),
+        'チ' if v == 'e' => "che".to_string(),
+        'シ' if v == 'e' => "she".to_string(),
+        'ジ' if v == 'e' => "je".to_string(),
+        _ => return None,
+    };
+    Some(r)
+}
+
+/// Pass 1: turn the katakana char stream into logical units, resolving 2-char
+/// combos (palatal / foreign) with one char of lookahead.
+fn lex(chars: &[char]) -> Vec<Unit> {
+    let mut units = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            'ッ' => {
+                units.push(Unit::Sokuon);
+                i += 1;
+            }
+            'ー' => {
+                units.push(Unit::Choon);
+                i += 1;
+            }
+            'ン' => {
+                units.push(Unit::N);
+                i += 1;
+            }
+            _ => {
+                if let Some(base) = kata_base(c) {
+                    // Try a 2-char combo with the next kana.
+                    if i + 1 < chars.len() {
+                        let next = chars[i + 1];
+                        if let Some(gv) = small_ya(next) {
+                            if let Some(p) = palatalize(base, gv) {
+                                units.push(Unit::Syl(p));
+                                i += 2;
+                                continue;
+                            }
+                        }
+                        if let Some(fc) = foreign_combo(c, next) {
+                            units.push(Unit::Syl(fc));
+                            i += 2;
+                            continue;
+                        }
+                    }
+                    units.push(Unit::Syl(base.to_string()));
+                    i += 1;
+                } else if let Some(v) = small_vowel(c) {
+                    // Stray small vowel: emit as plain vowel.
+                    units.push(Unit::Syl(v.to_string()));
+                    i += 1;
+                } else {
+                    // Non-kana: passthrough (coalesce runs into one Raw).
+                    let mut s = String::new();
+                    s.push(c);
+                    i += 1;
+                    units.push(Unit::Raw(s));
+                }
+            }
+        }
+    }
+    units
+}
+
+/// Pass 2: assemble units into a romaji string, applying gemination, long-vowel
+/// repetition and the n / n' apostrophe rule.
+fn assemble(units: &[Unit]) -> String {
+    let mut out = String::new();
+    let mut geminate = false;
+
+    for idx in 0..units.len() {
+        match &units[idx] {
+            Unit::Sokuon => {
+                geminate = true;
+            }
+            Unit::Choon => {
+                if let Some(v) = last_vowel(&out) {
+                    out.push(v);
+                }
+            }
+            Unit::N => {
+                out.push('n');
+                // Apostrophe if the next emitted sound starts with a vowel or y.
+                if let Some(next) = next_initial(units, idx + 1) {
+                    if is_vowel(next) || next == 'y' {
+                        out.push('\'');
+                    }
+                }
+            }
+            Unit::Syl(s) => {
+                if geminate {
+                    out.push_str(&geminate_prefix(s));
+                    geminate = false;
+                }
+                out.push_str(s);
+            }
+            Unit::Raw(s) => {
+                geminate = false;
+                out.push_str(s);
+            }
+        }
+    }
+    out
+}
+
+/// The consonant(s) a sokuon prepends before `s`. っち/ッチ -> "tch" (so ち's
+/// "chi" becomes "tchi"); otherwise the first consonant letter is doubled.
+fn geminate_prefix(s: &str) -> String {
+    if s.starts_with("ch") {
+        "t".to_string()
+    } else {
+        match s.chars().next() {
+            Some(c0) if !is_vowel(c0) && c0 != 'n' => c0.to_string(),
+            _ => String::new(),
+        }
+    }
+}
+
+/// First romaji letter that the unit at `idx` will emit (for the n' rule).
+fn next_initial(units: &[Unit], idx: usize) -> Option<char> {
+    match units.get(idx)? {
+        Unit::Syl(s) => s.chars().next(),
+        Unit::Raw(s) => s.chars().next(),
+        // A following sokuon/choon/n doesn't trigger the apostrophe.
+        _ => None,
+    }
+}
+
+fn last_vowel(s: &str) -> Option<char> {
+    s.chars().rev().find(|c| is_vowel(*c))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(s: &str) -> String {
+        romanize_kana(s)
+    }
+
+    #[test]
+    fn basic_syllables() {
+        assert_eq!(r("アクマジョウ"), "akumajou");
+        assert_eq!(r("ドコデモイッショ"), "dokodemoissho");
+        assert_eq!(r("チバ"), "chiba");
+        assert_eq!(r("ケン"), "ken");
+    }
+
+    #[test]
+    fn palatalized_and_foreign() {
+        assert_eq!(r("ドラキュラ"), "dorakyura");
+        assert_eq!(r("ファミコン"), "famikon");
+        assert_eq!(r("ジャンプ"), "janpu");
+        assert_eq!(r("シャイン"), "shain");
+    }
+
+    #[test]
+    fn chouonpu_repeats_vowel() {
+        assert_eq!(r("ガーン"), "gaan");
+        assert_eq!(r("ドドーン"), "dodoon");
+        assert_eq!(r("ラーメン"), "raamen");
+    }
+
+    #[test]
+    fn sokuon_gemination() {
+        assert_eq!(r("モット"), "motto");
+        assert_eq!(r("レッシャ"), "ressha");
+        assert_eq!(r("ヨッツ"), "yottsu");
+    }
+
+    #[test]
+    fn sokuon_tch_exception() {
+        assert_eq!(r("マッチャ"), "matcha");
+        assert_eq!(r("ボッチ"), "botchi");
+    }
+
+    #[test]
+    fn moraic_n_apostrophe() {
+        assert_eq!(r("レンアイ"), "ren'ai");
+        assert_eq!(r("センヨウ"), "sen'you");
+        // No apostrophe before a consonant.
+        assert_eq!(r("カンジ"), "kanji");
+        // Trailing n.
+        assert_eq!(r("ニホン"), "nihon");
+    }
+
+    #[test]
+    fn hiragana_normalized() {
+        assert_eq!(r("れっしゃ"), "ressha");
+        assert_eq!(r("どこでも"), "dokodemo");
+    }
+
+    #[test]
+    fn passthrough_non_kana() {
+        assert_eq!(r("２Ｄ"), "２Ｄ"); // full-width passthrough (not kana)
+        assert_eq!(r("ABC"), "ABC");
+    }
+
+    #[test]
+    fn macron_expansion() {
+        assert_eq!(expand_macrons("Tōkyō"), "Toukyou");
+        assert_eq!(expand_macrons("Yūsha"), "Yuusha");
+    }
+}

--- a/src/transliteration/japanese/romaji.rs
+++ b/src/transliteration/japanese/romaji.rs
@@ -119,25 +119,30 @@ fn kata_base(c: char) -> Option<&'static str> {
         'ラ' => "ra", 'リ' => "ri", 'ル' => "ru", 'レ' => "re", 'ロ' => "ro",
         'ワ' => "wa", 'ヰ' => "wi", 'ヱ' => "we", 'ヲ' => "o",
         'ヴ' => "vu",
+        // Small ke/ka used in place names and counters (希望ヶ峰 -> Kibougamine).
+        'ヶ' => "ga", 'ヵ' => "ka",
         _ => return None,
     };
     Some(s)
 }
 
-/// Combine an "i"-row base (ki, shi, chi, ji, ni, hi, mi, ri, gi, bi, pi) with a
-/// small ya/yu/yo glide: きゃ -> kya, しゃ -> sha, ちゃ -> cha, じゃ -> ja.
+/// Combine a base with a small ya/yu/yo glide. Covers i-row palatalization
+/// (きゃ -> kya, しゃ -> sha, ちゃ -> cha, じゃ -> ja) and foreign yōon on other
+/// rows (デュ -> dyu, テュ -> tyu, フュ -> fyu). Returns None for a pure-vowel base
+/// (no consonant to glide).
 fn palatalize(base: &str, glide_vowel: char) -> Option<String> {
-    if !base.ends_with('i') {
+    match base {
+        "shi" => return Some(format!("sh{glide_vowel}")),
+        "chi" => return Some(format!("ch{glide_vowel}")),
+        "ji" => return Some(format!("j{glide_vowel}")),
+        _ => {}
+    }
+    // Keep the leading consonant cluster, append "y" + the glide vowel.
+    let consonant: String = base.chars().take_while(|c| !is_vowel(*c)).collect();
+    if consonant.is_empty() {
         return None;
     }
-    let r = match base {
-        "shi" => format!("sh{glide_vowel}"),
-        "chi" => format!("ch{glide_vowel}"),
-        "ji" => format!("j{glide_vowel}"),
-        // ki -> ky, ni -> ny, hi -> hy, mi -> my, ri -> ry, gi -> gy, bi -> by, pi -> py
-        _ => format!("{}y{glide_vowel}", &base[..base.len() - 1]),
-    };
-    Some(r)
+    Some(format!("{consonant}y{glide_vowel}"))
 }
 
 /// Common foreign-sound combos: base + small vowel (ファ -> fa, ティ -> ti, ウィ -> wi).
@@ -203,6 +208,11 @@ fn lex(chars: &[char]) -> Vec<Unit> {
                 } else if let Some(v) = small_vowel(c) {
                     // Stray small vowel: emit as plain vowel.
                     units.push(Unit::Syl(v.to_string()));
+                    i += 1;
+                } else if let Some(v) = small_ya(c) {
+                    // Stray small ya/yu/yo (no combinable base before it): emit the
+                    // glide on its own so the raw kana never leaks (ャ -> ya).
+                    units.push(Unit::Syl(format!("y{v}")));
                     i += 1;
                 } else {
                     // Non-kana: passthrough (coalesce runs into one Raw).
@@ -307,6 +317,16 @@ mod tests {
         assert_eq!(r("ファミコン"), "famikon");
         assert_eq!(r("ジャンプ"), "janpu");
         assert_eq!(r("シャイン"), "shain");
+    }
+
+    #[test]
+    fn foreign_yoon_does_not_leak_raw_kana() {
+        // Small ya/yu/yo after a non-i-row base: デュ -> dyu, テュ -> tyu, フュ -> fyu.
+        assert_eq!(r("デューティー"), "dyuutii");
+        assert_eq!(r("テューバ"), "tyuuba");
+        assert_eq!(r("フュージョン"), "fyuujon");
+        // No leftover katakana in any output.
+        assert!(!r("デューティー").chars().any(|c| (c as u32) >= 0x3040));
     }
 
     #[test]

--- a/src/transliteration/mod.rs
+++ b/src/transliteration/mod.rs
@@ -14,7 +14,9 @@
 //! `detect::detect_script`.
 
 mod detect;
+pub mod greek;
 pub mod japanese;
+pub mod russian;
 
 pub use detect::detect_script;
 
@@ -25,13 +27,17 @@ use std::collections::HashMap;
 #[serde(rename_all = "snake_case")]
 pub enum Script {
     Japanese,
-    // future: Chinese, Greek, Cyrillic, ...
+    Russian,
+    Greek,
+    // future: Chinese, ...
 }
 
 impl Script {
     pub fn as_str(self) -> &'static str {
         match self {
             Script::Japanese => "japanese",
+            Script::Russian => "russian",
+            Script::Greek => "greek",
         }
     }
 }
@@ -78,6 +84,13 @@ impl TransliterationRegistry {
         let japanese = japanese::JapaneseTransliterator::new()?;
         backends.insert(Script::Japanese, Box::new(japanese));
 
+        backends.insert(
+            Script::Russian,
+            Box::new(russian::RussianTransliterator::new()),
+        );
+
+        backends.insert(Script::Greek, Box::new(greek::GreekTransliterator::new()));
+
         Ok(Self { backends })
     }
 
@@ -118,6 +131,17 @@ mod tests {
         assert!(reg.supports(Script::Japanese));
         let out = reg.transliterate("恋愛", None).unwrap();
         assert_eq!(out.text, "Ren'ai");
+    }
+
+    #[test]
+    fn registry_dispatches_by_explicit_script() {
+        let reg = TransliterationRegistry::new().expect("registry");
+        assert!(reg.supports(Script::Russian) && reg.supports(Script::Greek));
+        // The region-driven button passes the script explicitly.
+        let ru = reg.transliterate("Сон", Some(Script::Russian)).unwrap();
+        assert_eq!(ru.text, "Son");
+        let el = reg.transliterate("α", Some(Script::Greek)).unwrap();
+        assert_eq!(el.text, "Alpha");
     }
 
     #[test]

--- a/src/transliteration/mod.rs
+++ b/src/transliteration/mod.rs
@@ -1,0 +1,135 @@
+//! Transliteration subsystem.
+//!
+//! Converts text written in a non-Latin script into a Latin-script *draft*
+//! suitable for a Main Title. The public surface is script-agnostic:
+//!
+//! - [`Transliterator`] -- a backend for one writing system.
+//! - [`TransliterationRegistry`] -- owns the backends, detects the script (or
+//!   takes an explicit one), and dispatches.
+//! - [`Script`], [`TransliterationOutput`], [`TransliterationError`] -- shared types.
+//!
+//! Japanese (modified Hepburn) is the first backend. To add another script
+//! (Chinese, Greek, Cyrillic, ...): implement [`Transliterator`], add a variant
+//! to [`Script`], register it in [`TransliterationRegistry::new`], and extend
+//! `detect::detect_script`.
+
+mod detect;
+pub mod japanese;
+
+pub use detect::detect_script;
+
+use std::collections::HashMap;
+
+/// A supported writing system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Script {
+    Japanese,
+    // future: Chinese, Greek, Cyrillic, ...
+}
+
+impl Script {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Script::Japanese => "japanese",
+        }
+    }
+}
+
+/// Result of a transliteration.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TransliterationOutput {
+    /// The Latin-script draft.
+    pub text: String,
+    /// Which script backend produced it.
+    pub script: Script,
+    /// Non-fatal hints for the user (e.g. "review word spacing").
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransliterationError {
+    #[error("input contained no transliterable text")]
+    EmptyInput,
+    #[error("no transliterator available for the requested script")]
+    UnsupportedScript,
+    #[error("transliteration backend error: {0}")]
+    Backend(String),
+}
+
+/// A backend that transliterates one writing system.
+pub trait Transliterator: Send + Sync {
+    fn script(&self) -> Script;
+    fn transliterate(&self, input: &str) -> Result<TransliterationOutput, TransliterationError>;
+}
+
+/// Owns the available backends and dispatches by script. Construct once at
+/// startup (backends may load dictionaries) and share via `Arc`.
+pub struct TransliterationRegistry {
+    backends: HashMap<Script, Box<dyn Transliterator>>,
+}
+
+impl TransliterationRegistry {
+    /// Build the registry, constructing every backend. Returns an error if a
+    /// backend fails to initialize (e.g. dictionary load failure).
+    pub fn new() -> Result<Self, TransliterationError> {
+        let mut backends: HashMap<Script, Box<dyn Transliterator>> = HashMap::new();
+
+        let japanese = japanese::JapaneseTransliterator::new()?;
+        backends.insert(Script::Japanese, Box::new(japanese));
+
+        Ok(Self { backends })
+    }
+
+    /// Whether a backend exists for `script`.
+    pub fn supports(&self, script: Script) -> bool {
+        self.backends.contains_key(&script)
+    }
+
+    /// Transliterate `input`. If `script` is `None`, detect it from the text.
+    pub fn transliterate(
+        &self,
+        input: &str,
+        script: Option<Script>,
+    ) -> Result<TransliterationOutput, TransliterationError> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(TransliterationError::EmptyInput);
+        }
+        let script = match script.or_else(|| detect_script(trimmed)) {
+            Some(s) => s,
+            None => return Err(TransliterationError::UnsupportedScript),
+        };
+        let backend = self
+            .backends
+            .get(&script)
+            .ok_or(TransliterationError::UnsupportedScript)?;
+        backend.transliterate(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_dispatches_japanese() {
+        let reg = TransliterationRegistry::new().expect("registry");
+        assert!(reg.supports(Script::Japanese));
+        let out = reg.transliterate("恋愛", None).unwrap();
+        assert_eq!(out.text, "Ren'ai");
+    }
+
+    #[test]
+    fn empty_and_latin_are_errors() {
+        let reg = TransliterationRegistry::new().expect("registry");
+        assert!(matches!(
+            reg.transliterate("   ", None),
+            Err(TransliterationError::EmptyInput)
+        ));
+        assert!(matches!(
+            reg.transliterate("Dracula", None),
+            Err(TransliterationError::UnsupportedScript)
+        ));
+    }
+}

--- a/src/transliteration/russian.rs
+++ b/src/transliteration/russian.rs
@@ -1,0 +1,234 @@
+//! Russian (Cyrillic) transliteration — GOST 7.79-2000 **System B** (the
+//! diacritic-free system that uses letter combinations).
+//!
+//! Pure character mapping: no dictionary, no tokenizer, no dependencies. The
+//! only context rule is ц, which becomes "c" before i/e/y/j and "cz" elsewhere.
+//!
+//! Per redump's "without diacritics" convention (verified against the dataset),
+//! the System B modifier marks are written with an apostrophe rather than the
+//! strict backtick: ь -> ', ъ -> '', э -> e'; and ы drops its mark -> y
+//! (e.g. Объект -> Ob''ekt, Аэропорт -> Ae'roport, вампиры -> vampiry).
+//!
+//! Casing follows the source: an uppercase Cyrillic letter title-cases its Latin
+//! form (Ж -> "Zh"); an uppercase letter inside an ALL-CAPS run upper-cases the
+//! whole form (ЖУК -> "ZHUK"). This reproduces the Russian capitalization, so
+//! "Анабиоз: Сон разума" -> "Anabioz: Son razuma".
+
+use super::{Script, TransliterationError, TransliterationOutput, Transliterator};
+
+pub struct RussianTransliterator;
+
+impl RussianTransliterator {
+    pub fn new() -> Self {
+        RussianTransliterator
+    }
+}
+
+impl Transliterator for RussianTransliterator {
+    fn script(&self) -> Script {
+        Script::Russian
+    }
+
+    fn transliterate(&self, input: &str) -> Result<TransliterationOutput, TransliterationError> {
+        let chars: Vec<char> = input.chars().collect();
+        let mut out = String::with_capacity(input.len() * 2);
+
+        for i in 0..chars.len() {
+            let c = chars[i];
+            let lower = lower_char(c);
+            let next_lower = chars.get(i + 1).map(|n| lower_char(*n));
+
+            match base_latin(lower, next_lower) {
+                Some(latin) => {
+                    if c.is_uppercase() {
+                        out.push_str(&apply_case(&latin, in_caps_run(&chars, i)));
+                    } else {
+                        out.push_str(&latin);
+                    }
+                }
+                // Non-Russian characters (spaces, punctuation, digits, Latin)
+                // pass through unchanged.
+                None => out.push(c),
+            }
+        }
+
+        Ok(TransliterationOutput {
+            text: out,
+            script: Script::Russian,
+            notes: Vec::new(),
+        })
+    }
+}
+
+fn lower_char(c: char) -> char {
+    c.to_lowercase().next().unwrap_or(c)
+}
+
+/// GOST 7.79-2000 System B mapping for a lowercase Cyrillic letter. `next_lower`
+/// is the following lowercase letter, used for the ц context rule. Returns the
+/// lowercase Latin form, or None for non-Russian characters (passthrough).
+fn base_latin(lower: char, next_lower: Option<char>) -> Option<String> {
+    let s: &str = match lower {
+        'а' => "a",
+        'б' => "b",
+        'в' => "v",
+        'г' => "g",
+        'д' => "d",
+        'е' => "e",
+        'ё' => "yo",
+        'ж' => "zh",
+        'з' => "z",
+        'и' => "i",
+        'й' => "j",
+        'к' => "k",
+        'л' => "l",
+        'м' => "m",
+        'н' => "n",
+        'о' => "o",
+        'п' => "p",
+        'р' => "r",
+        'с' => "s",
+        'т' => "t",
+        'у' => "u",
+        'ф' => "f",
+        'х' => "x",
+        // ц -> "c" before i/e/y/j-initial letters, "cz" otherwise.
+        'ц' => {
+            return Some(if next_is_ieyj(next_lower) {
+                "c".to_string()
+            } else {
+                "cz".to_string()
+            })
+        }
+        'ч' => "ch",
+        'ш' => "sh",
+        'щ' => "shh",
+        // Redump convention (from dataset): System B marks written with an
+        // apostrophe, not the strict backtick; ы drops its mark entirely.
+        'ъ' => "''",
+        'ы' => "y",
+        'ь' => "'",
+        'э' => "e'",
+        'ю' => "yu",
+        'я' => "ya",
+        _ => return None,
+    };
+    Some(s.to_string())
+}
+
+/// Whether the next letter's Latin form starts with i, e, y, or j (the ц rule).
+fn next_is_ieyj(next_lower: Option<char>) -> bool {
+    matches!(
+        next_lower,
+        Some('и') | Some('е') | Some('э') | Some('ы') | Some('ю') | Some('я') | Some('ё') | Some('й')
+    )
+}
+
+/// True if the uppercase letter at `i` sits in an all-caps run (an adjacent
+/// cased Cyrillic letter is also uppercase).
+fn in_caps_run(chars: &[char], i: usize) -> bool {
+    let upper_neighbor = |j: usize| chars.get(j).is_some_and(|c| c.is_uppercase());
+    let prev = i > 0 && upper_neighbor(i - 1);
+    let next = upper_neighbor(i + 1);
+    prev || next
+}
+
+/// Apply source casing to a lowercase Latin form.
+fn apply_case(latin: &str, all_caps: bool) -> String {
+    if all_caps {
+        return latin.to_uppercase();
+    }
+    // Title-case: uppercase the first ASCII letter, leave the rest.
+    let mut done = false;
+    latin
+        .chars()
+        .map(|c| {
+            if !done && c.is_ascii_alphabetic() {
+                done = true;
+                c.to_ascii_uppercase()
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tr(s: &str) -> String {
+        RussianTransliterator.transliterate(s).unwrap().text
+    }
+
+    #[test]
+    fn official_example() {
+        assert_eq!(tr("Анабиоз: Сон разума"), "Anabioz: Son razuma");
+    }
+
+    #[test]
+    fn digraphs_and_special() {
+        assert_eq!(tr("жз"), "zhz");
+        assert_eq!(tr("щука"), "shhuka");
+        assert_eq!(tr("ёж"), "yozh");
+        assert_eq!(tr("Хорошо"), "Xorosho");
+    }
+
+    #[test]
+    fn tse_context_rule() {
+        assert_eq!(tr("цирк"), "cirk"); // ц before и -> c
+        assert_eq!(tr("цены"), "ceny"); // ц before е -> c
+        assert_eq!(tr("конец"), "konecz"); // ц not before i/e/y/j -> cz
+    }
+
+    #[test]
+    fn soft_hard_signs_and_yery() {
+        assert_eq!(tr("огонь"), "ogon'"); // soft sign -> apostrophe
+        assert_eq!(tr("подъезд"), "pod''ezd"); // hard sign -> double apostrophe
+        assert_eq!(tr("мы"), "my"); // ы -> y (mark dropped)
+        assert_eq!(tr("это"), "e'to"); // э -> e'
+    }
+
+    #[test]
+    fn casing_follows_source() {
+        assert_eq!(tr("Жук"), "Zhuk"); // title-case digraph
+        assert_eq!(tr("ЖУК"), "ZHUK"); // all-caps digraph
+        assert_eq!(tr("СССР"), "SSSR");
+    }
+
+    #[test]
+    fn latin_and_punctuation_passthrough() {
+        assert_eq!(tr("Sega Mega Drive"), "Sega Mega Drive");
+        assert_eq!(tr("Тетрис 2"), "Tetris 2");
+    }
+
+    #[test]
+    #[ignore = "analysis: RU_TSV=/tmp/ru_pairs.tsv cargo test ... analyze_russian -- --ignored --nocapture"]
+    fn analyze_russian() {
+        let path = std::env::var("RU_TSV").unwrap_or_default();
+        if path.is_empty() {
+            return;
+        }
+        let data = std::fs::read_to_string(&path).unwrap();
+        // Only score entries whose curated title is itself a romanization (has
+        // Cyrillic-derived structure), skipping ones replaced by an English title.
+        let (mut n, mut exact) = (0u64, 0u64);
+        let mut miss = Vec::new();
+        for line in data.lines() {
+            let Some((fg, ti)) = line.split_once('\t') else { continue };
+            let out = tr(fg);
+            // Heuristic: a romanization shares its first letter sound; skip clear
+            // English replacements by requiring the engine output to overlap.
+            n += 1;
+            if out == ti {
+                exact += 1;
+            } else if miss.len() < 20 {
+                miss.push((fg.to_string(), out, ti.to_string()));
+            }
+        }
+        println!("\n== Russian: {exact}/{n} exact ({:.1}%) ==", 100.0 * exact as f64 / n as f64);
+        for (fg, out, ti) in &miss {
+            println!("  {fg}\n    engine : {out}\n    curated: {ti}");
+        }
+    }
+}

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1945,6 +1945,21 @@ body:has(.disc-edit) footer.container hr {
     grid-column: 2;
     margin-top: 0.1rem;
 }
+.disc-edit .disc-meta-row > .transliterate-btn {
+    grid-column: 3;
+    justify-self: start;
+    width: max-content;
+    margin: 0;
+    padding: 0.15rem 0.6rem;
+    font-size: 0.8rem;
+    white-space: nowrap;
+}
+.disc-edit .disc-meta-row > .transliterate-note {
+    grid-column: 2 / -1;
+    margin-top: 0.15rem;
+    color: var(--pico-muted-color);
+    font-size: 0.8rem;
+}
 .disc-edit .grid {
     gap: 0.35rem;
 }

--- a/static/js/disc_edit.js
+++ b/static/js/disc_edit.js
@@ -871,6 +871,70 @@ function renderLayerbreaks() {
     }
 }
 
+// Transliterate the Foreign Title into the target (Title) field via the API.
+function setTransliterateNote(el, msg) {
+    if (!el) return;
+    el.textContent = msg || '';
+    el.style.display = msg ? '' : 'none';
+}
+
+function initTransliterate() {
+    var btn = document.getElementById('transliterate-btn');
+    if (!btn) return;
+    var note = document.getElementById('transliterate-note');
+    var foreign = document.querySelector('input[name="title_foreign"]');
+    var target = document.querySelector('input[name="' + (btn.dataset.target || 'title') + '"]');
+    if (!foreign || !target) {
+        btn.style.display = 'none';
+        return;
+    }
+
+    btn.addEventListener('click', function () {
+        var text = foreign.value.trim();
+        if (!text) {
+            setTransliterateNote(note, 'Enter a Foreign Title first.');
+            foreign.focus();
+            return;
+        }
+        // Don't silently clobber a title the user has already written.
+        if (target.value.trim() && target.value.trim() !== text) {
+            if (!window.confirm('Replace the current Title with the transliterated draft?')) {
+                return;
+            }
+        }
+
+        var original = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = '…';
+        setTransliterateNote(note, '');
+
+        fetch('/api/transliterate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: text })
+        }).then(function (resp) {
+            if (!resp.ok) {
+                return resp.text().then(function (t) {
+                    throw new Error(t || ('HTTP ' + resp.status));
+                });
+            }
+            return resp.json();
+        }).then(function (data) {
+            target.value = data.text || '';
+            // Notify auto-resize / other listeners that the value changed.
+            target.dispatchEvent(new Event('input', { bubbles: true }));
+            target.focus();
+            // Clear any prior message; we don't surface the draft notes in the UI.
+            setTransliterateNote(note, '');
+        }).catch(function (err) {
+            setTransliterateNote(note, 'Could not transliterate: ' + (err && err.message ? err.message : 'error'));
+        }).finally(function () {
+            btn.disabled = false;
+            btn.textContent = original;
+        });
+    });
+}
+
 // Init
 document.addEventListener('DOMContentLoaded', function () {
     filterMediaTypes();
@@ -882,6 +946,7 @@ document.addEventListener('DOMContentLoaded', function () {
     initEditionSelectors();
     initSubmitAsSelector();
     initFlagListToggle();
+    initTransliterate();
     initIndependentInlineResizing();
     fitDiscMetaFields();
     fitAllInlineGroups();

--- a/static/js/disc_edit.js
+++ b/static/js/disc_edit.js
@@ -878,6 +878,22 @@ function setTransliterateNote(el, msg) {
     el.style.display = msg ? '' : 'none';
 }
 
+// Region (flag code) -> transliteration script. Only regions whose script we
+// support show the Transliterate button.
+var REGION_SCRIPT = { jp: 'japanese', ru: 'russian', gr: 'greek' };
+
+// The script for the currently selected region(s), or null if none is supported.
+function selectedTransliterationScript() {
+    var inputs = document.querySelectorAll('input[name="regions"]');
+    for (var i = 0; i < inputs.length; i++) {
+        if (inputs[i].checked) {
+            var script = REGION_SCRIPT[(inputs[i].dataset.flag || '').toLowerCase()];
+            if (script) return script;
+        }
+    }
+    return null;
+}
+
 function initTransliterate() {
     var btn = document.getElementById('transliterate-btn');
     if (!btn) return;
@@ -889,7 +905,21 @@ function initTransliterate() {
         return;
     }
 
+    // Show the button only when the selected region has a supported script.
+    function refreshVisibility() {
+        btn.style.display = selectedTransliterationScript() ? '' : 'none';
+    }
+    refreshVisibility();
+    document.querySelectorAll('input[name="regions"]').forEach(function (input) {
+        input.addEventListener('change', refreshVisibility);
+    });
+
     btn.addEventListener('click', function () {
+        var script = selectedTransliterationScript();
+        if (!script) {
+            setTransliterateNote(note, 'Select a region with a supported script first.');
+            return;
+        }
         var text = foreign.value.trim();
         if (!text) {
             setTransliterateNote(note, 'Enter a Foreign Title first.');
@@ -911,7 +941,7 @@ function initTransliterate() {
         fetch('/api/transliterate', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ text: text })
+            body: JSON.stringify({ text: text, script: script })
         }).then(function (resp) {
             if (!resp.ok) {
                 return resp.text().then(function (t) {

--- a/templates/disc_edit.html
+++ b/templates/disc_edit.html
@@ -160,6 +160,7 @@ const IS_ADD_MODE = {{ is_add_mode }};
         <label class="disc-meta-row{% if !self.highlight_class("title_foreign").is_empty() %} {{ self.highlight_class("title_foreign") }}{% endif %}" data-field-flag="has_title_foreign"{% if !show_title_foreign %} style="display:none"{% endif %}>
             <span class="disc-meta-label">Foreign Title:</span>
             <input type="text" name="title_foreign" value="{{ title_foreign }}">
+            <button type="button" id="transliterate-btn" class="outline secondary transliterate-btn" data-target="title" title="Romanize the Foreign Title into the Title field (draft — review the result)">Transliterate</button>
             {% for ann in self.annotations_for("title_foreign") %}
             <div class="review-field-annotation">
                 <span class="review-field-annotation-label">{{ ann.label }}:</span>
@@ -168,6 +169,7 @@ const IS_ADD_MODE = {{ is_add_mode }};
                 {% endfor %}
             </div>
             {% endfor %}
+            <small class="transliterate-note" id="transliterate-note" role="status" aria-live="polite" style="display:none"></small>
         </label>
 
         <label class="disc-meta-row{% if !self.highlight_class("disc_number").is_empty() %} {{ self.highlight_class("disc_number") }}{% endif %}" data-field-flag="has_disc_number"{% if !show_disc_number %} style="display:none"{% endif %}>

--- a/templates/disc_edit.html
+++ b/templates/disc_edit.html
@@ -235,7 +235,7 @@ const IS_ADD_MODE = {{ is_add_mode }};
             <div class="flag-check-list">
             {% for r in regions %}
                 <label class="flag-check{% if is_add_mode && !r.common && !r.selected %} flag-check-extra{% endif %}{% if !r.highlight.is_empty() %} item-{{ r.highlight }}{% endif %}">
-                    <input type="{% if is_add_mode %}radio{% else %}checkbox{% endif %}" name="regions" value="{{ r.value }}" {% if r.selected %}checked{% endif %}>
+                    <input type="{% if is_add_mode %}radio{% else %}checkbox{% endif %}" name="regions" value="{{ r.value }}" data-flag="{{ r.code }}" {% if r.selected %}checked{% endif %}>
                     <img class="flag-icon" src="/static/flags/{{ r.code }}.svg" title="{{ r.name }}" alt="{{ r.name }}">
                     <span>{{ r.name }}</span>
                 </label>


### PR DESCRIPTION
Adds a **Transliterate** button beside the Foreign Title field on the Add/Edit disc form that generates a Latin-script Title draft. The button is **region-driven**: the selected Region picks the ruleset and the button auto-shows/hides.

## Backends
- **Japanese** — modified Hepburn via `lindera`/IPADIC: kana table, palatalization, chouonpu, sokuon (incl. っち→tch), ん→n/n', particles via POS. Normalization (fullwidth→ASCII, Roman numerals, 『』→", 【】/「」 stripped, ・→space, monospace-aware separators, ・-letter-spelling, 、/。). ~90 dataset-verified, tokenizer-aligned overrides (official romanizations, over-split kanji compounds, recurring loanwords/franchises). Produces a reviewed *draft* (loanword restoration and word-spacing are deliberately left to the submitter).
- **Russian** — GOST 7.79-2000 **System B** with the redump "without diacritics" apostrophe convention (ь→', ъ→'', э→e', ы→y; ц→c/cz context rule), verified against the dataset (~58% exact, the rest mostly English-title choices / inconsistent source data). Zero dependencies.
- **Greek** — expands Greek letters to their English names (α→Alpha, Σ→Sigma, Φ→Phi…), matching the catalog's symbol usage. Zero dependencies.

## Architecture
- Generic `Transliterator` trait + `TransliterationRegistry` + script detection; each script is a self-contained backend (easy to add more).
- `POST /api/transliterate` (auth-gated). The button passes the **explicit script** from the region, so e.g. 三國志 = Sangokushi (Japan) vs Sanguozhi (China) is disambiguated by region rather than guessed.

## Region → ruleset
Japan → Japanese, Russia → Russian, Greece → Greek (others: button hidden). Asia/Export/China deferred for a future Chinese (pinyin) backend.

## Notes
- `Dockerfile`: Rust 1.85 → 1.94 (lindera/ICU MSRV). The embedded IPADIC adds ~50 MB to the binary; per-call cost is ~7 µs.
- 48 unit tests; several `#[ignore]`d dev/analysis tools for re-mining overrides against the dataset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transliteration support for Japanese, Russian, and Greek scripts to English romanized text.
  * Integrated a "Transliterate" button in the disc editor's Foreign Title field.
  * Automatic script detection for supported languages.
  * Transliteration API endpoint now available for authenticated requests.

* **Chores**
  * Updated Docker build environment to Rust 1.94.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->