### PR TITLE
Limit transliteration input length to prevent misuse

### DIFF
--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -32,10 +32,10 @@ async fn transliterate(
         .transliteration
         .transliterate(&req.text, req.script)
         .map_err(|e| match e {
-            // Nothing to romanize (empty, or already Latin) is a client problem.
-            TransliterationError::EmptyInput | TransliterationError::UnsupportedScript => {
-                AppError::BadRequest(e.to_string())
-            }
+            // Client problems: empty, too long, or nothing transliterable.
+            TransliterationError::EmptyInput
+            | TransliterationError::TooLong
+            | TransliterationError::UnsupportedScript => AppError::BadRequest(e.to_string()),
             TransliterationError::Backend(msg) => AppError::Internal(msg),
         })?;
 

--- a/src/transliteration/mod.rs
+++ b/src/transliteration/mod.rs
@@ -53,10 +53,17 @@ pub struct TransliterationOutput {
     pub notes: Vec<String>,
 }
 
+/// Maximum accepted input length, in characters. Matches the `title_foreign`
+/// column (VARCHAR(512)); anything longer is not a real title and is rejected to
+/// prevent abuse.
+pub const MAX_INPUT_CHARS: usize = 512;
+
 #[derive(Debug, thiserror::Error)]
 pub enum TransliterationError {
     #[error("input contained no transliterable text")]
     EmptyInput,
+    #[error("input exceeds the maximum length of {MAX_INPUT_CHARS} characters")]
+    TooLong,
     #[error("no transliterator available for the requested script")]
     UnsupportedScript,
     #[error("transliteration backend error: {0}")]
@@ -109,6 +116,9 @@ impl TransliterationRegistry {
         if trimmed.is_empty() {
             return Err(TransliterationError::EmptyInput);
         }
+        if trimmed.chars().count() > MAX_INPUT_CHARS {
+            return Err(TransliterationError::TooLong);
+        }
         let script = match script.or_else(|| detect_script(trimmed)) {
             Some(s) => s,
             None => return Err(TransliterationError::UnsupportedScript),
@@ -155,5 +165,13 @@ mod tests {
             reg.transliterate("Dracula", None),
             Err(TransliterationError::UnsupportedScript)
         ));
+        // Over-long input is rejected (abuse guard).
+        let too_long = "あ".repeat(MAX_INPUT_CHARS + 1);
+        assert!(matches!(
+            reg.transliterate(&too_long, None),
+            Err(TransliterationError::TooLong)
+        ));
+        // Exactly at the limit is fine.
+        assert!(reg.transliterate(&"あ".repeat(MAX_INPUT_CHARS), None).is_ok());
     }
 }

--- a/static/js/disc_edit.js
+++ b/static/js/disc_edit.js
@@ -926,6 +926,11 @@ function initTransliterate() {
             foreign.focus();
             return;
         }
+        // Mirror the server limit (title_foreign is VARCHAR(512)).
+        if (text.length > 512) {
+            setTransliterateNote(note, 'Foreign Title is too long to transliterate (max 512 characters).');
+            return;
+        }
         // Don't silently clobber a title the user has already written.
         if (target.value.trim() && target.value.trim() !== text) {
             if (!window.confirm('Replace the current Title with the transliterated draft?')) {


### PR DESCRIPTION
Adds a maximum input length to the transliteration endpoint so it can't be misused with oversized payloads.

- Rejects Foreign Title input longer than **512 characters** (matching the `title_foreign VARCHAR(512)` column) via a new `TransliterationError::TooLong`, enforced in the registry entry point.
- `POST /api/transliterate` maps it to **400 Bad Request** (protects the endpoint even when called directly).
- The button also pre-checks length and shows a friendly message before calling the API.

This caps the per-request tokenization work (cost scales with input length), so large payloads can't bog the server down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added input length validation for transliteration requests with a maximum of 512 characters
* Validation is enforced on both the client side and server side for consistency
* Users receive clear error messages when their input exceeds the established character limit
* Oversized transliteration requests are now properly rejected as client-side errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->