### PR TITLE
[codex] Add homepage recent changes

### DIFF
--- a/src/routes/main_page.rs
+++ b/src/routes/main_page.rs
@@ -6,6 +6,9 @@ use crate::config::SiteConfig;
 use crate::services::news_service::NewsItem;
 use crate::AppState;
 
+const HOME_RECENT_LIMIT: i64 = 30;
+const HOME_NEWS_LIMIT: usize = 3;
+
 pub fn routes() -> Router<AppState> {
     Router::new().route("/", get(homepage))
 }
@@ -16,6 +19,7 @@ struct MainTemplate {
     current_user: Option<String>,
     news_items: Vec<NewsItem>,
     recent_discs: Vec<RecentDisc>,
+    recent_changes: Vec<RecentChange>,
 }
 impl SiteConfig for MainTemplate {}
 
@@ -27,13 +31,21 @@ struct RecentDisc {
     created_at: String,
 }
 
+struct RecentChange {
+    id: i32,
+    title: String,
+    system: String,
+    region_flags: Vec<HomeRegionFlag>,
+    modified_at: String,
+}
+
 struct HomeRegionFlag {
     code: String,
     name: String,
 }
 
 async fn homepage(State(state): State<AppState>, user: CurrentUser) -> Html<String> {
-    let news_items = state
+    let mut news_items = state
         .news_cache
         .get(&state.http, &state.config.news_feed_url)
         .await
@@ -41,6 +53,7 @@ async fn homepage(State(state): State<AppState>, user: CurrentUser) -> Html<Stri
             tracing::warn!("Failed to load homepage news: {err}");
             Vec::new()
         });
+    news_items.truncate(HOME_NEWS_LIMIT);
 
     let rows: Vec<RecentDiscRow> = sqlx::query_as(
         "SELECT d.id, d.title, s.code AS system_code, s.short_name AS system_short_name,
@@ -51,37 +64,52 @@ async fn homepage(State(state): State<AppState>, user: CurrentUser) -> Html<Stri
          JOIN systems s ON s.code = d.system_code
          WHERE d.status != 'Disabled'
          ORDER BY d.id DESC
-         LIMIT 30",
+         LIMIT $1",
     )
+    .bind(HOME_RECENT_LIMIT)
     .fetch_all(&state.pool)
     .await
     .unwrap_or_default();
 
     let mut recent_discs = Vec::with_capacity(rows.len());
     for r in rows {
-        let region_rows: Vec<HomeRegionRow> = sqlx::query_as(
-            "SELECT r.flag_code AS code, r.name FROM disc_regions dr
-             JOIN regions r ON r.code = dr.region_code
-             WHERE dr.disc_id = $1 ORDER BY r.sort_order",
-        )
-        .bind(r.id)
-        .fetch_all(&state.pool)
-        .await
-        .unwrap_or_default();
-
         recent_discs.push(RecentDisc {
             id: r.id,
             title: r.title,
             system: crate::db::models::short_system_display(&r.system_short_name, &r.system_code),
-            region_flags: region_rows
-                .into_iter()
-                .map(|rr| HomeRegionFlag {
-                    code: rr.code.to_lowercase(),
-                    name: rr.name,
-                })
-                .collect(),
+            region_flags: load_home_region_flags(&state.pool, r.id).await,
             created_at: r
                 .created_at
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+        });
+    }
+
+    let change_rows: Vec<RecentChangeRow> = sqlx::query_as(
+        "SELECT d.id, d.title, s.code AS system_code, s.short_name AS system_short_name,
+                MAX(ds.created_at) AS modified_at
+         FROM discs d
+         JOIN systems s ON s.code = d.system_code
+         JOIN disc_submissions ds ON ds.target_disc_id = d.id
+         WHERE d.status != 'Disabled'
+         GROUP BY d.id, d.title, s.code, s.short_name
+         ORDER BY MAX(ds.created_at) DESC, d.id DESC
+         LIMIT $1",
+    )
+    .bind(HOME_RECENT_LIMIT)
+    .fetch_all(&state.pool)
+    .await
+    .unwrap_or_default();
+
+    let mut recent_changes = Vec::with_capacity(change_rows.len());
+    for r in change_rows {
+        recent_changes.push(RecentChange {
+            id: r.id,
+            title: r.title,
+            system: crate::db::models::short_system_display(&r.system_short_name, &r.system_code),
+            region_flags: load_home_region_flags(&state.pool, r.id).await,
+            modified_at: r
+                .modified_at
                 .map(|d| d.format("%Y-%m-%d").to_string())
                 .unwrap_or_default(),
         });
@@ -92,6 +120,7 @@ async fn homepage(State(state): State<AppState>, user: CurrentUser) -> Html<Stri
             current_user: user.user().map(|u| u.username.clone()),
             news_items,
             recent_discs,
+            recent_changes,
         }
         .render()
         .unwrap(),
@@ -108,7 +137,36 @@ struct RecentDiscRow {
 }
 
 #[derive(sqlx::FromRow)]
+struct RecentChangeRow {
+    id: i32,
+    title: String,
+    system_code: String,
+    system_short_name: String,
+    modified_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(sqlx::FromRow)]
 struct HomeRegionRow {
     code: String,
     name: String,
+}
+
+async fn load_home_region_flags(pool: &sqlx::PgPool, disc_id: i32) -> Vec<HomeRegionFlag> {
+    let region_rows: Vec<HomeRegionRow> = sqlx::query_as(
+        "SELECT r.flag_code AS code, r.name FROM disc_regions dr
+         JOIN regions r ON r.code = dr.region_code
+         WHERE dr.disc_id = $1 ORDER BY r.sort_order",
+    )
+    .bind(disc_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    region_rows
+        .into_iter()
+        .map(|rr| HomeRegionFlag {
+            code: rr.code.to_lowercase(),
+            name: rr.name,
+        })
+        .collect()
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -156,7 +156,7 @@ main > h3 {
     color: inherit;
 }
 [data-theme="dark"] .disc-table .title-col a {
-    color: #E8FCFF;
+    color: #CDE6F3;
 }
 .disc-table .title-col .foreign-title {
     margin-top: 0.08rem;
@@ -165,21 +165,21 @@ main > h3 {
     color: #6b7280;
 }
 [data-theme="dark"] .disc-table .title-col .foreign-title {
-    color: #d7dee8;
+    color: #C0C6D0;
 }
 .disc-table .submission-title-col a {
     color: inherit;
 }
 [data-theme="dark"] .disc-table .submission-title-col a {
-    color: #E8FCFF;
+    color: #CDE6F3;
 }
 [data-theme="dark"] .disc-table th:not(.title-col) a,
 [data-theme="dark"] .disc-table td:not(.title-col):not(.submission-title-col) a {
-    color: #c8e2eb;
+    color: #BED4DF;
 }
 [data-theme="dark"] .disc-table th:not(.title-col) a:hover,
 [data-theme="dark"] .disc-table td:not(.title-col):not(.submission-title-col) a:hover {
-    color: #d8eef5;
+    color: #DDEFF7;
 }
 
 .submission-type-icon {
@@ -323,7 +323,7 @@ table.striped td {
     color: #565e6a;
 }
 [data-theme="dark"] .qa-question {
-    color: #e0e5ec;
+    color: #C8CED8;
 }
 .qa-answer {
     font-size: 0.85rem;
@@ -364,7 +364,7 @@ table.striped td {
     vertical-align: middle;
 }
 [data-theme="dark"] .downloads-table th {
-    color: #e0e5ec;
+    color: #C8CED8;
 }
 .downloads-table .downloads-group-header {
     text-align: center;
@@ -501,7 +501,7 @@ details + p small {
     background-color: #E8F2FA;
 }
 [data-theme="dark"] .letter-picker a:hover {
-    background-color: #1E2A3A;
+    background-color: #212B38;
 }
 .letter-picker a.active {
     background: var(--pico-primary);
@@ -536,7 +536,7 @@ details + p small {
     border-bottom: none !important;
 }
 [data-theme="dark"] .disc-view table tbody tr:nth-child(odd) td {
-    background-color: #10151D !important;
+    background-color: #12161C !important;
 }
 
 /* Disc view page — compact layout */
@@ -919,7 +919,7 @@ details + p small {
     background: #F5F9FC;
 }
 [data-theme="dark"] .disc-view .section-collapsible .pre-wrap {
-    background: #10151D;
+    background: #12161C;
 }
 .disc-view .section-collapsible .disc-comments,
 .disc-view .section-collapsible .disc-contents {
@@ -984,7 +984,7 @@ details + p small {
     background: #F5F9FC;
 }
 [data-theme="dark"] .disc-title-box {
-    border-color: #2a3140;
+    border-color: #2B3645;
     background: transparent;
 }
 
@@ -1100,9 +1100,9 @@ details + p small {
     color: #5c6673;
 }
 [data-theme="dark"] .disc-view .files-table tbody tr.files-synthetic-row td {
-    background-color: #141A23 !important;
-    border-top-color: #4a5568 !important;
-    color: #d7dee8;
+    background-color: #181C24 !important;
+    border-top-color: #4A5462 !important;
+    color: #C0C6D0;
 }
 /* Keep ring rows aligned when # column is row-spanned */
 .disc-view .table-scroll-compact > table.ring-table {
@@ -1123,7 +1123,7 @@ details + p small {
     border-top: 1px solid #F5F9FC;
 }
 [data-theme="dark"] .ring-group-start > td {
-    border-top-color: #2a3140;
+    border-top-color: #2B3645;
 }
 .ring-entry-even > td {
     background: rgba(0,0,0,0.04);
@@ -1145,7 +1145,7 @@ details + p small {
     color: inherit;
 }
 [data-theme="dark"] .ring-table .ring-fixed-cell {
-    color: #d7dee8;
+    color: #C0C6D0;
 }
 .ring-tab-marker {
     display: inline-block;
@@ -1159,7 +1159,7 @@ details + p small {
     background: rgba(0, 0, 0, 0.06) !important;
 }
 [data-theme="dark"] .disc-view .tracks-table.striped tbody tr.tracks-session-row td {
-    background: #141A23 !important;
+    background: #181C24 !important;
 }
 .tracks-table .tracks-total-row td {
     border-top: var(--pico-border-width) solid var(--pico-form-element-border-color);
@@ -1278,16 +1278,16 @@ header .site-nav-top {
     white-space: nowrap;
 }
 [data-theme="dark"] .user-menu-button {
-    border-color: #5a6b82;
+    border-color: #607085;
     background: var(--pico-form-element-background-color);
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.25);
 }
 [data-theme="dark"] .user-menu-button:is(:hover, :focus) {
-    background: #1E2A3A;
+    background: #212B38;
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.25);
 }
 [data-theme="dark"] .user-menu-icon {
-    border-right-color: #5a6b82;
+    border-right-color: #607085;
     background: transparent;
     box-shadow: none;
 }
@@ -1446,11 +1446,11 @@ header .site-nav-links > li:first-child {
 }
 [data-theme="dark"] .site-nav-links > li > a:hover,
 [data-theme="dark"] .site-nav-links > li > .submenu-label:hover {
-    background-color: #1E2A3A;
+    background-color: #212B38;
 }
 [data-theme="dark"] .site-nav-links > li > a[aria-current="page"] {
-    background-color: #141A23;
-    color: #E8FCFF;
+    background-color: #181C24;
+    color: #CDE6F3;
 }
 
 /* Nav submenu dropdown */
@@ -1459,7 +1459,7 @@ header .site-nav-links > li:first-child {
     color: var(--pico-primary);
 }
 [data-theme="dark"] .submenu-label {
-    color: #E8FCFF;
+    color: #CDE6F3;
 }
 .has-submenu {
     position: relative;
@@ -1480,7 +1480,7 @@ header .site-nav-links > li:first-child {
     min-width: 10rem;
 }
 [data-theme="dark"] .has-submenu .submenu {
-    background: #0F141C;
+    background: #14181E;
 }
 .user-menu .submenu {
     top: 100%;
@@ -1541,7 +1541,7 @@ header .site-nav-links > li:first-child {
 }
 [data-theme="dark"] .submenu li a:hover,
 [data-theme="dark"] .submenu li .submenu-button:hover {
-    background: #1E2A3A !important;
+    background: #212B38 !important;
 }
 .submenu li .submenu-disabled {
     color: var(--pico-muted-color);
@@ -1586,7 +1586,7 @@ nav .quick-search input[type="text"] {
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.08);
 }
 [data-theme="dark"] nav .quick-search input[type="text"] {
-    border-color: #5a6b82;
+    border-color: #607085;
     background-color: var(--pico-form-element-background-color);
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.25);
 }
@@ -1677,7 +1677,7 @@ nav .quick-search input[type="text"] {
     line-height: 1.15;
 }
 [data-theme="dark"] .home-news .home-news-meta {
-    color: #d1d8e2;
+    color: #A6AFBD;
 }
 .home-news-content {
     color: var(--pico-color);
@@ -1722,7 +1722,7 @@ nav .quick-search input[type="text"] {
 }
 [data-theme="dark"] .home-news-actions a,
 [data-theme="dark"] .home-news-forum-link a {
-    color: #e0e5ec;
+    color: #C8CED8;
 }
 .home-news-forum-link {
     text-align: center;
@@ -1823,16 +1823,16 @@ table.striped tbody tr.clickable-row.is-row-hover td {
 [data-theme="dark"] .recent-dumps tbody tr.clickable-row.is-row-hover td,
 [data-theme="dark"] table.striped tbody tr.clickable-row:hover td,
 [data-theme="dark"] table.striped tbody tr.clickable-row.is-row-hover td {
-    background-color: #1E2A3A !important;
+    background-color: #212B38 !important;
 }
 [data-theme="dark"] .recent-dumps tbody tr.clickable-row,
 [data-theme="dark"] .disc-table tbody tr.clickable-row {
-    --pico-color: #c2c7d0;
-    color: #c2c7d0;
+    --pico-color: #EDECEF;
+    color: #EDECEF;
 }
 [data-theme="dark"] .clickable-row:focus-visible td {
-    background-color: #1E2A3A !important;
-    box-shadow: inset 0 1px 0 #4f6f8d, inset 0 -1px 0 #4f6f8d;
+    background-color: #212B38 !important;
+    box-shadow: inset 0 1px 0 #506176, inset 0 -1px 0 #506176;
 }
 
 /* Queue status dots */
@@ -1862,8 +1862,8 @@ table.striped tbody tr.clickable-row.is-row-hover td {
     transition: background 0.2s, box-shadow 0.2s;
 }
 [data-theme="dark"] .dark-mode-toggle {
-    background: #141A23;
-    box-shadow: 0 0 0 1.5px #5a6b82, inset 0 1px 2px rgba(0,0,0,0.35);
+    background: #181C24;
+    box-shadow: 0 0 0 1.5px #607085, inset 0 1px 2px rgba(0,0,0,0.35);
 }
 .dark-mode-toggle:focus-visible {
     outline: 2px solid #0172ad;
@@ -1880,7 +1880,7 @@ table.striped tbody tr.clickable-row.is-row-hover td {
 }
 [data-theme="dark"] .dark-mode-toggle-thumb {
     margin-top: 14px;
-    background: #E8FCFF;
+    background: #EDECEF;
 }
 
 /* Responsive nav adjustments */
@@ -2121,7 +2121,7 @@ body:has(.disc-edit) footer.container hr {
     padding-left: 0.85rem;
 }
 [data-theme="dark"] .flag-select-languages {
-    border-left-color: #2a3140;
+    border-left-color: #2B3645;
 }
 .disc-edit input[type="radio"] {
     margin: 0;
@@ -2569,16 +2569,16 @@ body:has(.disc-edit) footer.container hr {
     outline-offset: 2px;
 }
 [data-theme="dark"] .ring-edit-table .ring-layer-label-tooltip:focus {
-    outline-color: #5a6b82;
+    outline-color: #607085;
 }
 [data-theme="dark"] .ring-edit-table .ring-layer-label-tooltip::before {
-    border-right-color: #141a23;
-    filter: drop-shadow(-1px 0 0 #303947);
+    border-right-color: #181C24;
+    filter: drop-shadow(-1px 0 0 #35404D);
 }
 [data-theme="dark"] .ring-edit-table .ring-layer-label-tooltip::after {
-    border-color: #303947;
-    background: #141a23;
-    color: #d8e1ec;
+    border-color: #35404D;
+    background: #181C24;
+    color: #C8CED8;
     box-shadow: 0 0.3rem 0.85rem rgba(0, 0, 0, 0.45);
 }
 .ring-edit-table .remove-entry {
@@ -2926,21 +2926,22 @@ body:has(.submission-info) main.container > section h3 {
 /* ===== Dark mode overrides ===== */
 [data-theme="dark"],
 [data-theme="dark"] body {
-    --pico-background-color: #04080C;
-    --pico-card-background-color: #0F141C;
-    --pico-card-sectioning-background-color: #141A23;
-    --pico-form-element-background-color: #0F141C;
-    --pico-code-background-color: #0F141C;
-    --pico-muted-border-color: #243244;
-    --pico-muted-color: #e0e5ec;
-    background: #04080C;
-    color: #ffffff;
+    --pico-background-color: #0C0E12;
+    --pico-card-background-color: #14181E;
+    --pico-card-sectioning-background-color: #181C24;
+    --pico-form-element-background-color: #14181E;
+    --pico-code-background-color: #14181E;
+    --pico-muted-border-color: #2B3645;
+    --pico-color: #EDECEF;
+    --pico-muted-color: #B8C0CC;
+    background: #0C0E12;
+    color: #EDECEF;
 }
 [data-theme="dark"] a {
-    color: #E8FCFF;
+    color: #CDE6F3;
 }
 [data-theme="dark"] a:hover {
-    color: #E8FCFF;
+    color: #DDEFF7;
 }
 [data-theme="dark"] .validation-result a,
 [data-theme="dark"] .validation-result a:hover {
@@ -2948,16 +2949,16 @@ body:has(.submission-info) main.container > section h3 {
 }
 /* Headers and More... match h3 heading color in dark mode */
 [data-theme="dark"] .recent-dumps th {
-    color: #e0e5ec;
+    color: #C8CED8;
 }
 [data-theme="dark"] .home-recent-dumps p a,
 [data-theme="dark"] .home-recent-changes p a {
-    color: #e0e5ec;
+    color: #C8CED8;
 }
 [data-theme="dark"] .recent-dumps td,
 [data-theme="dark"] table.striped tbody tr td,
 [data-theme="dark"] .disc-view table td {
-    background-color: #0F141C !important;
+    background-color: #14181E !important;
 }
 /* Alternating rows — home page and striped tables */
 [data-theme="dark"] .recent-dumps tbody tr:nth-child(odd) td,
@@ -2967,9 +2968,9 @@ body:has(.submission-info) main.container > section h3 {
 }
 [data-theme="dark"] .clickable-row:hover td,
 [data-theme="dark"] .clickable-row.is-row-hover td {
-    background-color: #1E2A3A !important;
+    background-color: #212B38 !important;
 }
 [data-theme="dark"] .clickable-row:focus-visible td {
-    background-color: #1E2A3A !important;
-    box-shadow: inset 0 1px 0 #4f6f8d, inset 0 -1px 0 #4f6f8d;
+    background-color: #212B38 !important;
+    box-shadow: inset 0 1px 0 #506176, inset 0 -1px 0 #506176;
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1174,8 +1174,8 @@ header .site-nav {
     align-items: stretch;
     gap: 0;
     padding: 0 !important;
-    padding-top: 1.25rem !important;
-    padding-bottom: 0.65rem !important;
+    padding-top: 0.85rem !important;
+    padding-bottom: 0.3rem !important;
     overflow: visible;
 }
 
@@ -1306,7 +1306,7 @@ header .site-nav-links {
     flex-direction: row !important;
     flex-wrap: nowrap !important;
     list-style: none;
-    margin: 1.25rem auto 1.15rem !important;
+    margin: 1rem auto 0.65rem !important;
     padding: 0.08rem 0 !important;
     align-items: center;
     justify-content: center;
@@ -1599,18 +1599,31 @@ nav .quick-search input[type="text"] {
     gap: 1rem;
     padding-top: 0;
 }
-.home-sections section {
+.home-sections > section,
+.home-data-column {
     width: 100%;
     max-width: 820px;
+    text-align: center;
+}
+.home-data-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1.15rem;
+}
+.home-data-column section {
+    width: 100%;
+    max-width: 100%;
     text-align: center;
 }
 @media (min-width: 1640px) {
     .home-sections {
         flex-direction: row;
         align-items: flex-start;
+        column-gap: clamp(1rem, calc((100vw - 1640px) / 5), 5rem);
         justify-content: center;
     }
-    .home-sections section {
+    .home-sections > section,
+    .home-sections > .home-data-column {
         flex: 0 1 820px;
     }
 }
@@ -1702,7 +1715,7 @@ nav .quick-search input[type="text"] {
 }
 .home-news-actions a,
 .home-news-forum-link a {
-    color: #565e6a;
+    color: #035c90;
     font-weight: 600;
     text-decoration-thickness: 1px;
     text-underline-offset: 0.18em;
@@ -1712,30 +1725,42 @@ nav .quick-search input[type="text"] {
     color: #e0e5ec;
 }
 .home-news-forum-link {
-    text-align: left;
+    text-align: center;
 }
 .home-recent-dumps .recent-dumps {
     margin: 0 auto;
     text-align: left;
     width: 100%;
 }
+.home-recent-changes {
+    display: none;
+}
 .home-recent-dumps .recent-dumps tbody tr:nth-child(n+21) {
     display: none;
 }
 @media (min-width: 1640px) {
+    .home-recent-changes {
+        display: block;
+        padding-top: 0.9rem;
+    }
     .home-recent-dumps .recent-dumps tbody tr:nth-child(n+21) {
         display: table-row;
     }
     .home-recent-dumps .recent-dumps tbody tr:nth-child(n+31) {
         display: none;
     }
+    .home-recent-changes .recent-changes tbody tr:nth-child(n+31) {
+        display: none;
+    }
 }
-.home-recent-dumps p {
+.home-recent-dumps p,
+.home-recent-changes p {
     margin-top: 0.5rem;
     margin-bottom: 0;
 }
-.home-recent-dumps p a {
-    color: #565e6a;
+.home-recent-dumps p a,
+.home-recent-changes p a {
+    color: #035c90;
     font-weight: bold;
 }
 
@@ -2925,7 +2950,8 @@ body:has(.submission-info) main.container > section h3 {
 [data-theme="dark"] .recent-dumps th {
     color: #e0e5ec;
 }
-[data-theme="dark"] .home-recent-dumps p a {
+[data-theme="dark"] .home-recent-dumps p a,
+[data-theme="dark"] .home-recent-changes p a {
     color: #e0e5ec;
 }
 [data-theme="dark"] .recent-dumps td,

--- a/templates/main.html
+++ b/templates/main.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <div class="home-sections">
+    <div class="home-data-column">
     <section class="home-recent-dumps">
         <h3>Recent Dumps</h3>
         <div class="recent-dumps-scaler">
@@ -40,6 +41,43 @@
         <p><a href="/discs/?sort=added&amp;order=desc">More...</a></p>
     </section>
 
+    <section class="home-recent-changes">
+        <h3>Recent Changes</h3>
+        <div class="recent-changes-scaler">
+        <table class="recent-dumps recent-changes">
+            <thead>
+                <tr>
+                    <th class="date-col">Modified</th>
+                    <th class="region-col">Region</th>
+                    <th>Title</th>
+                    <th>System</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for disc in recent_changes %}
+                <tr class="clickable-row" data-href="/disc/{{ disc.id }}/" tabindex="0" role="link">
+                    <td class="date-col">{{ disc.modified_at }}</td>
+                    <td class="region-col"><span class="region-flags">
+                        {% for rf in disc.region_flags %}
+                        <img class="flag-icon" src="/static/flags/{{ rf.code }}.svg"
+                             title="{{ rf.name }}"
+                             alt="{{ rf.name }}">
+                        {% endfor %}
+                    </span></td>
+                    <td><a href="/disc/{{ disc.id }}/">{{ disc.title }}</a></td>
+                    <td>{{ disc.system }}</td>
+                </tr>
+                {% endfor %}
+                {% if recent_changes.is_empty() %}
+                <tr><td colspan="4">No changes yet.</td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+        </div>
+        <p><a href="/discs/?sort=updated&amp;order=desc">More...</a></p>
+    </section>
+    </div>
+
     <section class="home-news">
         <h3>News</h3>
         {% if news_items.is_empty() %}
@@ -64,14 +102,14 @@
             </article>
             {% endfor %}
         </div>
-        <p class="home-news-forum-link"><a href="{{ self.forum_url() }}">More discussion on the forum</a></p>
+        <p class="home-news-forum-link"><a href="{{ self.forum_url() }}">More...</a></p>
         {% endif %}
     </section>
 </div>
 <script>
 (function() {
-    function scaleRecentDumps() {
-        var wrapper = document.querySelector('.recent-dumps-scaler');
+    function scaleHomeTables() {
+        document.querySelectorAll('.recent-dumps-scaler, .recent-changes-scaler').forEach(function(wrapper) {
         var table = wrapper && wrapper.querySelector('table');
         if (!table) return;
         table.style.transform = '';
@@ -88,9 +126,10 @@
             wrapper.style.height = Math.ceil(table.offsetHeight * scale) + 'px';
             wrapper.style.overflow = 'hidden';
         }
+        });
     }
-    document.addEventListener('DOMContentLoaded', scaleRecentDumps);
-    window.addEventListener('resize', scaleRecentDumps);
+    document.addEventListener('DOMContentLoaded', scaleHomeTables);
+    window.addEventListener('resize', scaleHomeTables);
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add a desktop-only Recent Changes table to the home page, using disc submission timestamps.
- Limit the home page news feed to 3 items.
- Tune home page spacing/link presentation for the Recent Dumps, Recent Changes, and News columns.
- Rebalance dark mode toward a less navy, blue-grey palette with clearer primary, muted, link, and metadata text hierarchy.

## Validation
- `docker compose up -d --build app`
- Rust test suite in Docker: 158 passed, 0 failed, 7 ignored
- Browser checks on the home page in dark mode, including computed color/contrast samples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Recent Changes" section to the homepage, displaying recently updated items with modification timestamps and region information.

* **Style**
  * Refreshed dark mode color palette across navigation, links, forms, and tables for improved visual consistency.
  * Enhanced homepage layout with improved section alignment, spacing, and responsive design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->