### PR TITLE
[codex] Improve mobile filters and header spacing

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -622,6 +622,37 @@ details + p small {
     line-height: 1.2;
 }
 
+@media (max-width: 640px) {
+    #filter-form,
+    #filter-form.advanced-search-visible {
+        grid-template-columns: minmax(0, 1fr);
+        width: 100%;
+        max-width: 100%;
+        justify-items: stretch;
+    }
+    #filter-form label,
+    #filter-form:not(.advanced-search-visible) label,
+    #filter-form.advanced-search-visible label,
+    #filter-form .advanced-search-row,
+    #filter-form.advanced-search-visible .advanced-search-row {
+        box-sizing: border-box;
+        grid-template-columns: 4.75rem minmax(0, 1fr);
+        justify-self: center;
+        width: min(100%, 20rem);
+        max-width: 100%;
+    }
+    #filter-form select,
+    #filter-form.advanced-search-visible select,
+    #filter-form.advanced-search-visible select[name="region"],
+    #filter-form.advanced-search-visible select[name="status"],
+    #filter-form .advanced-search-row select,
+    #filter-form.advanced-search-visible .advanced-search-row input[type="text"] {
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+    }
+}
+
 /* Letter picker */
 .letter-picker {
     display: flex;
@@ -1329,7 +1360,7 @@ header .site-nav {
     align-items: stretch;
     gap: 0;
     padding: 0 !important;
-    padding-top: 0.85rem !important;
+    padding-top: 0.3rem !important;
     padding-bottom: 0.3rem !important;
     overflow: visible;
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -695,6 +695,25 @@ details + p small {
     border-color: var(--pico-primary);
 }
 
+@media (max-width: 640px) {
+    .letter-picker {
+        display: grid;
+        grid-template-columns: repeat(14, minmax(0, 1fr));
+        gap: 0.12rem;
+        width: min(100%, 22rem);
+        max-width: 100%;
+    }
+    .letter-picker a,
+    .letter-picker a:not(:first-child) {
+        width: auto;
+        min-width: 0;
+        min-height: 0;
+        aspect-ratio: 1;
+        padding: 0;
+        font-size: 0.72rem;
+    }
+}
+
 /* Hex dump */
 .hex-dump {
     font-family: 'Courier New', Courier, monospace;

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/static/favicon.ico" sizes="any">
     <link rel="shortcut icon" href="/static/favicon.ico">
     <link rel="stylesheet" href="/static/css/pico.min.css">
-    <link rel="stylesheet" href="/static/css/app.css?v=20260606-collapsed-gap-10">
+    <link rel="stylesheet" href="/static/css/app.css">
     <script>
         (function() {
             var t = localStorage.getItem('theme');

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/static/favicon.ico" sizes="any">
     <link rel="shortcut icon" href="/static/favicon.ico">
     <link rel="stylesheet" href="/static/css/pico.min.css">
-    <link rel="stylesheet" href="/static/css/app.css">
+    <link rel="stylesheet" href="/static/css/app.css?v=20260606-collapsed-gap-10">
     <script>
         (function() {
             var t = localStorage.getItem('theme');


### PR DESCRIPTION
## What changed

- Adds a mobile-only clamp for Disc Database filter rows so System/Region and Advanced Search controls fit within the viewport.
- Centers the mobile label/control rows at a max width of 20rem.
- Reduces the top padding above the header logo row to 0.3rem.

## Why

The Disc Database filter controls could visually hug or spill beyond the mobile viewport, especially around long selected system names. The header also had more top whitespace than desired.

## Validation

- docker compose up -d --build app
- Build test run passed: 175 passed; 0 failed; 7 ignored
- Verified at a 390px mobile viewport that closed filter controls fit without horizontal overflow and header padding computes to 4.8px.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced mobile responsiveness with optimized layouts for the filter form and letter picker on smaller screens.
  * Refined navigation spacing for improved visual hierarchy on desktop displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->