### PR TITLE
Disc UI: center top columns, keep Comments expanded, rename sort label

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -799,9 +799,11 @@ details + p small {
     display: grid;
     grid-template-areas: "disc dump aux";
     grid-template-columns: fit-content(var(--disc-info-max-width)) max-content fit-content(var(--disc-aux-max-width));
-    justify-content: space-evenly;
+    /* Center the three columns as a group; padding between them is bounded
+       (min 1.5rem .. max 3.5rem, scaling with viewport). */
+    justify-content: center;
     align-items: start;
-    gap: 0.5rem 1rem;
+    gap: 0.5rem clamp(1.5rem, 4vw, 3.5rem);
     margin-bottom: 2.5rem;
 }
 .disc-view .disc-side-stack {

--- a/templates/disc_view.html
+++ b/templates/disc_view.html
@@ -112,15 +112,8 @@
             {% endif %}
 
             {% if !comments.is_empty() %}
-            {% if comments.lines().count() > 10 %}
-            <details class="protection-details">
-                <summary><h3>Comments</h3></summary>
-                <p class="pre-wrap disc-comments">{{ comments|safe }}</p>
-            </details>
-            {% else %}
             <h3>Comments</h3>
             <p class="pre-wrap disc-comments">{{ comments|safe }}</p>
-            {% endif %}
             {% endif %}
 
             {% if !contents.is_empty() %}

--- a/templates/discs.html
+++ b/templates/discs.html
@@ -67,7 +67,7 @@
                 <input type="text" name="comments_q" value="{{ filter_comments_q }}">
             </label>
             <label class="advanced-search-row">
-                <span>Sort by</span>
+                <span>Order</span>
                 <select class="sort-select" onchange="var p=this.value.split('|');this.form.sort.value=p[0];this.form.order.value=p[1];this.form.submit();">
                     <option value="title|asc" {% if sort_column == "title" %}selected{% endif %}>Alphabetical</option>
                     <option value="added|desc" {% if sort_column == "added" && sort_order == "desc" %}selected{% endif %}>Added Date: Newest</option>


### PR DESCRIPTION
## Summary
Small disc-page and Advanced Search UI refinements.

- **Disc page — top columns**: the Disc / Dump / Protection-Comments columns now **center as a group** with a **bounded gap** (`clamp(1.5rem, 4vw, 3.5rem)`) instead of `space-evenly` spreading them across the full width. Mobile breakpoints (≤960px, ≤760px) are unchanged.
- **Disc page — Comments**: always rendered **expanded** (removed the collapse-into-`<details>` behavior for long comments). Protection and Contents keep their collapse.
- **Advanced Search**: renamed the **"Sort by"** label to **"Order"**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined disc grid layout with responsive spacing and centered alignment.
  * Updated filter label from "Sort by" to "Order".

* **Bug Fixes**
  * Simplified comment rendering in disc view for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->