### PR TITLE
Fix system order

### DIFF
--- a/src/routes/discs.rs
+++ b/src/routes/discs.rs
@@ -345,7 +345,7 @@ async fn discs_page(
 
     let sys_rows: Vec<SystemDropdownRow> = sqlx::query_as(
         "SELECT code, manufacturer, name FROM systems
-         ORDER BY LOWER(COALESCE(NULLIF(manufacturer, ''), name)), LOWER(name)",
+         ORDER BY LOWER(CONCAT_WS(' ', NULLIF(manufacturer, ''), name))",
     )
     .fetch_all(&state.pool)
     .await
@@ -471,7 +471,7 @@ async fn discs_page(
             "(SELECT MIN(r.sort_order) FROM disc_regions dr JOIN regions r ON r.code = dr.region_code WHERE dr.disc_id = d.id)"
         }
         "title" => display_title_sort_sql(),
-        "system" => "LOWER(COALESCE(NULLIF(s.manufacturer, ''), s.name)), LOWER(s.name)",
+        "system" => "LOWER(CONCAT_WS(' ', NULLIF(s.manufacturer, ''), s.name))",
         "version" => "LOWER(d.version)",
         "edition" => "LOWER(array_to_string(d.edition, ', '))",
         "language" => {

--- a/src/routes/discs.rs
+++ b/src/routes/discs.rs
@@ -345,7 +345,7 @@ async fn discs_page(
 
     let sys_rows: Vec<SystemDropdownRow> = sqlx::query_as(
         "SELECT code, manufacturer, name FROM systems
-         ORDER BY LOWER(manufacturer), manufacturer, LOWER(name), name",
+         ORDER BY LOWER(s.manufacturer || ' ' || s.name)",
     )
     .fetch_all(&state.pool)
     .await
@@ -471,7 +471,7 @@ async fn discs_page(
             "(SELECT MIN(r.sort_order) FROM disc_regions dr JOIN regions r ON r.code = dr.region_code WHERE dr.disc_id = d.id)"
         }
         "title" => display_title_sort_sql(),
-        "system" => "LOWER(s.manufacturer), s.manufacturer, LOWER(s.name), s.name",
+        "system" => "LOWER(s.manufacturer || ' ' || s.name)",
         "version" => "LOWER(d.version)",
         "edition" => "LOWER(array_to_string(d.edition, ', '))",
         "language" => {

--- a/src/routes/discs.rs
+++ b/src/routes/discs.rs
@@ -345,7 +345,7 @@ async fn discs_page(
 
     let sys_rows: Vec<SystemDropdownRow> = sqlx::query_as(
         "SELECT code, manufacturer, name FROM systems
-         ORDER BY LOWER(CONCAT(s.manufacturer, ' ', s.name))",
+         ORDER BY LOWER(CONCAT(manufacturer, ' ', name))",
     )
     .fetch_all(&state.pool)
     .await

--- a/src/routes/discs.rs
+++ b/src/routes/discs.rs
@@ -345,7 +345,7 @@ async fn discs_page(
 
     let sys_rows: Vec<SystemDropdownRow> = sqlx::query_as(
         "SELECT code, manufacturer, name FROM systems
-         ORDER BY LOWER(s.manufacturer || ' ' || s.name)",
+         ORDER BY LOWER(CONCAT(s.manufacturer, ' ', s.name))",
     )
     .fetch_all(&state.pool)
     .await
@@ -471,7 +471,7 @@ async fn discs_page(
             "(SELECT MIN(r.sort_order) FROM disc_regions dr JOIN regions r ON r.code = dr.region_code WHERE dr.disc_id = d.id)"
         }
         "title" => display_title_sort_sql(),
-        "system" => "LOWER(s.manufacturer || ' ' || s.name)",
+        "system" => "LOWER(CONCAT(s.manufacturer, ' ', s.name))",
         "version" => "LOWER(d.version)",
         "edition" => "LOWER(array_to_string(d.edition, ', '))",
         "language" => {

--- a/src/routes/discs.rs
+++ b/src/routes/discs.rs
@@ -345,7 +345,7 @@ async fn discs_page(
 
     let sys_rows: Vec<SystemDropdownRow> = sqlx::query_as(
         "SELECT code, manufacturer, name FROM systems
-         ORDER BY LOWER(CONCAT(manufacturer, ' ', name))",
+         ORDER BY LOWER(COALESCE(NULLIF(manufacturer, ''), name)), LOWER(name)",
     )
     .fetch_all(&state.pool)
     .await
@@ -471,7 +471,7 @@ async fn discs_page(
             "(SELECT MIN(r.sort_order) FROM disc_regions dr JOIN regions r ON r.code = dr.region_code WHERE dr.disc_id = d.id)"
         }
         "title" => display_title_sort_sql(),
-        "system" => "LOWER(CONCAT(s.manufacturer, ' ', s.name))",
+        "system" => "LOWER(COALESCE(NULLIF(s.manufacturer, ''), s.name)), LOWER(s.name)",
         "version" => "LOWER(d.version)",
         "edition" => "LOWER(array_to_string(d.edition, ', '))",
         "language" => {

--- a/src/routes/downloads.rs
+++ b/src/routes/downloads.rs
@@ -104,7 +104,7 @@ async fn downloads_page(State(state): State<AppState>, user: CurrentUser) -> Htm
     let rows: Vec<SystemDownloadRow> = sqlx::query_as(
         "SELECT s.code, s.manufacturer, s.name, s.has_key, s.has_sbi, s.media_types
          FROM systems s
-         ORDER BY LOWER(s.manufacturer), s.manufacturer, LOWER(s.name), s.name",
+         ORDER BY LOWER(s.manufacturer || ' ' || s.name)",
     )
     .fetch_all(&state.pool)
     .await

--- a/src/routes/downloads.rs
+++ b/src/routes/downloads.rs
@@ -104,7 +104,7 @@ async fn downloads_page(State(state): State<AppState>, user: CurrentUser) -> Htm
     let rows: Vec<SystemDownloadRow> = sqlx::query_as(
         "SELECT s.code, s.manufacturer, s.name, s.has_key, s.has_sbi, s.media_types
          FROM systems s
-         ORDER BY LOWER(COALESCE(NULLIF(manufacturer, ''), name)), LOWER(name)",
+         ORDER BY LOWER(COALESCE(NULLIF(s.manufacturer, ''), s.name)), LOWER(s.name)",
     )
     .fetch_all(&state.pool)
     .await

--- a/src/routes/downloads.rs
+++ b/src/routes/downloads.rs
@@ -104,7 +104,7 @@ async fn downloads_page(State(state): State<AppState>, user: CurrentUser) -> Htm
     let rows: Vec<SystemDownloadRow> = sqlx::query_as(
         "SELECT s.code, s.manufacturer, s.name, s.has_key, s.has_sbi, s.media_types
          FROM systems s
-         ORDER BY LOWER(s.manufacturer || ' ' || s.name)",
+         ORDER BY LOWER(CONCAT(s.manufacturer, ' ', s.name))",
     )
     .fetch_all(&state.pool)
     .await

--- a/src/routes/downloads.rs
+++ b/src/routes/downloads.rs
@@ -104,7 +104,7 @@ async fn downloads_page(State(state): State<AppState>, user: CurrentUser) -> Htm
     let rows: Vec<SystemDownloadRow> = sqlx::query_as(
         "SELECT s.code, s.manufacturer, s.name, s.has_key, s.has_sbi, s.media_types
          FROM systems s
-         ORDER BY LOWER(CONCAT(s.manufacturer, ' ', s.name))",
+         ORDER BY LOWER(COALESCE(NULLIF(manufacturer, ''), name)), LOWER(name)",
     )
     .fetch_all(&state.pool)
     .await

--- a/src/routes/downloads.rs
+++ b/src/routes/downloads.rs
@@ -104,7 +104,7 @@ async fn downloads_page(State(state): State<AppState>, user: CurrentUser) -> Htm
     let rows: Vec<SystemDownloadRow> = sqlx::query_as(
         "SELECT s.code, s.manufacturer, s.name, s.has_key, s.has_sbi, s.media_types
          FROM systems s
-         ORDER BY LOWER(COALESCE(NULLIF(s.manufacturer, ''), s.name)), LOWER(s.name)",
+         ORDER BY LOWER(CONCAT_WS(' ', NULLIF(s.manufacturer, ''), s.name))",
     )
     .fetch_all(&state.pool)
     .await

--- a/src/routes/queue.rs
+++ b/src/routes/queue.rs
@@ -266,7 +266,7 @@ async fn queue_list(
 
     let sys_rows: Vec<SysRow> = sqlx::query_as(
         "SELECT code, manufacturer, name FROM systems
-         ORDER BY LOWER(manufacturer), manufacturer, LOWER(name), name",
+         ORDER BY LOWER(CONCAT_WS(' ', NULLIF(manufacturer, ''), name))",
     )
     .fetch_all(&state.pool)
     .await

--- a/src/services/disc_service.rs
+++ b/src/services/disc_service.rs
@@ -553,7 +553,7 @@ pub fn sort_ring_codes_json(entries: &mut [serde_json::Value], max_layers: usize
 pub async fn get_all_systems(pool: &PgPool) -> AppResult<Vec<System>> {
     Ok(sqlx::query_as(
         "SELECT * FROM systems
-         ORDER BY LOWER(manufacturer), manufacturer, LOWER(name), name",
+         ORDER BY LOWER(CONCAT(manufacturer, ' ', name))",
     )
     .fetch_all(pool)
     .await?)

--- a/src/services/disc_service.rs
+++ b/src/services/disc_service.rs
@@ -553,7 +553,7 @@ pub fn sort_ring_codes_json(entries: &mut [serde_json::Value], max_layers: usize
 pub async fn get_all_systems(pool: &PgPool) -> AppResult<Vec<System>> {
     Ok(sqlx::query_as(
         "SELECT * FROM systems
-         ORDER BY LOWER(COALESCE(NULLIF(manufacturer, ''), name)), LOWER(name)",
+         ORDER BY LOWER(CONCAT_WS(' ', NULLIF(manufacturer, ''), name))",
     )
     .fetch_all(pool)
     .await?)

--- a/src/services/disc_service.rs
+++ b/src/services/disc_service.rs
@@ -553,7 +553,7 @@ pub fn sort_ring_codes_json(entries: &mut [serde_json::Value], max_layers: usize
 pub async fn get_all_systems(pool: &PgPool) -> AppResult<Vec<System>> {
     Ok(sqlx::query_as(
         "SELECT * FROM systems
-         ORDER BY LOWER(CONCAT(manufacturer, ' ', name))",
+         ORDER BY LOWER(COALESCE(NULLIF(manufacturer, ''), name)), LOWER(name)",
     )
     .fetch_all(pool)
     .await?)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated system sorting on the **Discs**, **Downloads**, and **Queue** pages to be consistent and case-insensitive.
  * Sorting now uses a single combined manufacturer+name key (treating empty manufacturer as missing) to determine order.
  * The discs table’s `sort=system` behavior now matches the systems dropdown ordering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->