### PR TITLE
Improve mobile Recent Dumps table

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2127,6 +2127,43 @@ nav .quick-search input[type="text"] {
     width: 1%;
     white-space: nowrap;
 }
+@media (max-width: 768px) {
+    .home-recent-dumps .recent-dumps {
+        table-layout: fixed;
+    }
+    .recent-dumps th {
+        padding: 0.025rem 0.09rem;
+        font-size: 0.66rem;
+    }
+    .recent-dumps td {
+        padding: 0.025rem 0.09rem;
+        font-size: 0.62rem;
+    }
+    .recent-dumps .date-col {
+        width: 3.85rem;
+        padding-left: 0.05rem;
+        padding-right: 0.05rem;
+    }
+    .recent-dumps .region-col {
+        width: 3rem;
+    }
+    .recent-dumps th.region-col {
+        white-space: nowrap;
+    }
+    .recent-dumps .region-col .region-flags {
+        max-width: calc(2 * 1.55em);
+    }
+    .recent-dumps .title-col {
+        padding-left: 0.08rem;
+    }
+    .recent-dumps .title-col a {
+        max-width: 100%;
+    }
+    .recent-dumps .system-col {
+        padding-right: 0.08rem;
+        width: 3.35rem;
+    }
+}
 .clickable-row {
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- add mobile-specific sizing for the Home page Recent Dumps table
- keep Region header on one line and fit System values like Audio CD
- let long titles use the available title column width with ellipsis

## Verification
- cargo check
- measured 390px mobile viewport via Chrome/Playwright

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile responsiveness for the recent dumps table on small screens, including optimized layout, font sizes, padding, and column widths for better readability on devices under 768px width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->