### PR TITLE
[codex] Polish queue table layout

### DIFF
--- a/docker/mediawiki/LocalSettings.php
+++ b/docker/mediawiki/LocalSettings.php
@@ -139,6 +139,7 @@ if ($mediawikiEmailEnabled) {
 # Default skin
 $wgDefaultSkin = "vector-2022";
 wfLoadSkin('Vector');
+$wgDefaultUserOptions['vector-appearance-pinned'] = 1;
 
 # Disable anonymous editing and account creation
 $wgGroupPermissions['*']['edit'] = false;

--- a/src/transliteration/japanese/mod.rs
+++ b/src/transliteration/japanese/mod.rs
@@ -348,6 +348,7 @@ mod tests {
     fn official_romanization_override() {
         assert_eq!(tr("ファミコン"), "Famicom");
         assert_eq!(tr("ラーメン"), "Ramen");
+        assert_eq!(tr("アクションリプレイ"), "Action Replay");
     }
 
     #[test]

--- a/src/transliteration/japanese/overrides.rs
+++ b/src/transliteration/japanese/overrides.rs
@@ -161,6 +161,7 @@ const PHRASE_SEED: &[(&str, &str)] = &[
     //     co-occurrences, fragments, and titles with varying printed English
     //     (バイオハザード) were excluded. ---
     ("ファイナルファンタジー", "Final Fantasy"), // 223
+    ("アクションリプレイ", "Action Replay"),
     ("ドラマ", "Drama"),                         // 254
     ("ガンダム", "Gundam"),                      // 171
     ("サクラ", "Sakura"),                        // 135

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2217,6 +2217,30 @@ table.striped tbody tr.clickable-row.is-row-hover td {
 }
 
 /* Queue status dots */
+.queue-table-scroll {
+    width: 100%;
+    text-align: center;
+}
+
+.queue-table {
+    display: inline-table;
+    width: max-content;
+    min-width: 0;
+    table-layout: auto;
+    text-align: left;
+}
+
+.queue-table th,
+.queue-table td {
+    white-space: nowrap;
+    padding-inline-end: 0.75rem;
+}
+
+.queue-table th:last-child,
+.queue-table td:last-child {
+    padding-inline-end: 0.35rem;
+}
+
 .status-dot-pending  { background: #f39c12; }
 .status-dot-approved { background: var(--status-verified); }
 .status-dot-rejected { background: var(--status-bad); }

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -83,7 +83,8 @@
     </nav>
     {% endif %}
 
-    <table class="disc-table striped">
+    <div class="table-scroll queue-table-scroll">
+    <table class="disc-table striped table-nowrap queue-table">
         <thead>
             <tr>
                 <th class="date-col"><a href="/queue?sort=date&amp;order={{ next_date_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Date{% if sort_column == "date" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
@@ -91,21 +92,21 @@
                 <th class="submission-title-col"><a href="/queue?sort=title&amp;order={{ next_title_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Submission Title{% if sort_column == "title" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
                 <th class="disc-id-col"><a href="/queue?sort=disc_id&amp;order={{ next_disc_id_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Disc ID{% if sort_column == "disc_id" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
                 <th class="system-col"><a href="/queue?sort=system&amp;order={{ next_system_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">System{% if sort_column == "system" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
-                <th><a href="/queue?sort=submitter&amp;order={{ next_submitter_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Submitter{% if sort_column == "submitter" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
-                <th><a href="/queue?sort=reviewer&amp;order={{ next_reviewer_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Reviewer{% if sort_column == "reviewer" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
+                <th class="submitter-col"><a href="/queue?sort=submitter&amp;order={{ next_submitter_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Submitter{% if sort_column == "submitter" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
+                <th class="reviewer-col"><a href="/queue?sort=reviewer&amp;order={{ next_reviewer_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Reviewer{% if sort_column == "reviewer" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
                 <th class="status-col"><a href="/queue?sort=status&amp;order={{ next_status_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Status{% if sort_column == "status" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
             </tr>
         </thead>
         <tbody>
             {% for entry in entries %}
-            <tr>
+            <tr{% if self.can_open_entry(entry) %} class="clickable-row" data-href="/queue/{{ entry.id }}" tabindex="0" role="link"{% endif %}>
                 <td class="date-col">{{ entry.created_at.format("%Y-%m-%d %H:%M") }}</td>
                 <td class="type-col"><span class="{{ self.type_icon_class(entry) }}" role="img" aria-label="{{ self.type_icon_label(entry) }}" title="{{ self.type_icon_label(entry) }}"></span></td>
                 <td class="submission-title-col">{% if self.can_open_entry(entry) %}<a href="/queue/{{ entry.id }}">{{ entry.title }}</a>{% else %}{{ entry.title }}{% endif %}</td>
                 <td class="disc-id-col">{% match entry.target_disc_id %}{% when Some with (disc_id) %}<a href="/disc/{{ disc_id }}">{{ disc_id }}</a>{% when None %}{% endmatch %}</td>
                 <td class="system-col">{{ entry.system_display }}</td>
-                <td><a href="/discs?dumper={{ self.url_encode(entry.submitter) }}">{{ entry.submitter }}</a></td>
-                <td>{% match entry.reviewer_id %}{% when Some with (_) %}<a href="/discs?dumper={{ self.url_encode(entry.reviewer.as_deref().unwrap_or("")) }}">{{ entry.reviewer.as_deref().unwrap_or("") }}</a>{% when None %}{% endmatch %}</td>
+                <td class="submitter-col"><a href="/discs?dumper={{ self.url_encode(entry.submitter) }}">{{ entry.submitter }}</a></td>
+                <td class="reviewer-col">{% match entry.reviewer_id %}{% when Some with (_) %}<a href="/discs?dumper={{ self.url_encode(entry.reviewer.as_deref().unwrap_or("")) }}">{{ entry.reviewer.as_deref().unwrap_or("") }}</a>{% when None %}{% endmatch %}</td>
                 <td class="status-col" title="{{ entry.status }}">{% match entry.status %}{% when SubmissionStatus::Pending %}🟡{% when SubmissionStatus::Approved %}🟢{% when SubmissionStatus::Rejected %}🔴{% when SubmissionStatus::Legacy %}⚪{% endmatch %}</td>
             </tr>
             {% endfor %}
@@ -114,6 +115,7 @@
             {% endif %}
         </tbody>
     </table>
+    </div>
 
     {% if total_pages > 1 %}
     <nav aria-label="Pagination">


### PR DESCRIPTION
## Summary
- Make the queue table content-sized so each column fits its widest value with added spacing.
- Center the queue table when it is narrower than the viewport while keeping cell content left-aligned.
- Make openable queue rows use the existing full-row hover/click behavior.
- Add the requested Action Replay Japanese transliteration override.
- Default Vector 2022's Appearance sidebar to pinned for logged-in MediaWiki users.

## Validation
- `git diff --check`
- `cargo test routes::queue::tests`
- `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Japanese transliteration phrase override for improved translation accuracy.
  * Redesigned queue page table layout with horizontal scrolling support and clickable row navigation.

* **Tests**
  * Updated transliteration unit tests to validate new override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->