### PR TITLE
Improve submission change displays

### DIFF
--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -1049,6 +1049,8 @@ pub struct SubmissionRingChangeRow {
     pub mould_sids: SubmissionRingChangeCell,
     pub additional_moulds: SubmissionRingChangeCell,
     pub offset: SubmissionRingChangeCell,
+    pub offset_extra: SubmissionRingChangeCell,
+    pub sample_start: SubmissionRingChangeCell,
     pub comment: SubmissionRingChangeCell,
 }
 
@@ -1064,6 +1066,57 @@ pub struct SubmissionChangeDetail {
     pub previous_kind: String,
     pub ring_rows: Vec<SubmissionRingChangeRow>,
     pub show_ring_layers: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionChangeScalarRow {
+    pub field: String,
+    pub action: String,
+    pub previous_value: String,
+    pub current_value: String,
+    pub status_class: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionChangeSetRow {
+    pub field: String,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionChangeMultilineRow {
+    pub field: String,
+    pub action: String,
+    pub previous_value: String,
+    pub current_value: String,
+    pub status_class: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionChangeRingSection {
+    pub label: String,
+    pub ring_rows: Vec<SubmissionRingChangeRow>,
+    pub show_ring_layers: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionChangeFallbackRow {
+    pub path: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionChangesView {
+    pub title: String,
+    pub note: String,
+    pub has_changes: bool,
+    pub scalar_rows: Vec<SubmissionChangeScalarRow>,
+    pub set_rows: Vec<SubmissionChangeSetRow>,
+    pub multiline_rows: Vec<SubmissionChangeMultilineRow>,
+    pub legacy_rows: Vec<SubmissionChangeScalarRow>,
+    pub ring_sections: Vec<SubmissionChangeRingSection>,
+    pub fallback_rows: Vec<SubmissionChangeFallbackRow>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -1033,11 +1033,47 @@ pub fn compute_file_hashes(data: &[u8]) -> (i64, String, String, String) {
 }
 
 #[derive(Debug, Clone)]
+pub struct SubmissionRingChangeCell {
+    pub value: String,
+    pub status_class: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionRingChangeRow {
+    pub entry_num: usize,
+    pub entry_rowspan: usize,
+    pub layer_label: String,
+    pub mastering_code: SubmissionRingChangeCell,
+    pub mastering_sid: SubmissionRingChangeCell,
+    pub toolstamps: SubmissionRingChangeCell,
+    pub mould_sids: SubmissionRingChangeCell,
+    pub additional_moulds: SubmissionRingChangeCell,
+    pub offset: SubmissionRingChangeCell,
+    pub comment: SubmissionRingChangeCell,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubmissionChangeDetail {
+    pub label: String,
+    pub current_value: String,
+    pub previous_value: String,
+    pub is_multiline: bool,
+    pub current_label: String,
+    pub previous_label: String,
+    pub current_kind: String,
+    pub previous_kind: String,
+    pub ring_rows: Vec<SubmissionRingChangeRow>,
+    pub show_ring_layers: bool,
+}
+
+#[derive(Debug, Clone)]
 pub struct SubmissionListRow {
     pub id: i32,
     pub submission_type: SubmissionType,
     pub display_kind: SubmissionDisplayKind,
     pub title: String,
+    pub submission_comment: String,
+    pub change_details: Vec<SubmissionChangeDetail>,
     pub system_code: String,
     pub system_display: String,
     pub submitter: String,

--- a/src/routes/disc_edit.rs
+++ b/src/routes/disc_edit.rs
@@ -183,8 +183,7 @@ pub(crate) struct DiscEditTemplate {
     pub review_comment_input: String,
     pub created_at_display: String,
     pub reviewed_at_display: String,
-    pub changes_original_json: String,
-    pub changes_json: String,
+    pub change_views: Vec<SubmissionChangesView>,
 }
 impl SiteConfig for DiscEditTemplate {}
 
@@ -1044,8 +1043,7 @@ async fn edit_page(
             review_comment_input: String::new(),
             created_at_display: String::new(),
             reviewed_at_display: String::new(),
-            changes_original_json: String::new(),
-            changes_json: String::new(),
+            change_views: vec![],
         }
         .render()
         .unwrap(),
@@ -1636,8 +1634,7 @@ async fn render_form_with_errors(
         review_comment_input: String::new(),
         created_at_display: String::new(),
         reviewed_at_display: String::new(),
-        changes_original_json: String::new(),
-        changes_json: String::new(),
+        change_views: vec![],
     };
 
     let status =
@@ -2370,8 +2367,7 @@ async fn add_page(
             review_comment_input: String::new(),
             created_at_display: String::new(),
             reviewed_at_display: String::new(),
-            changes_original_json: String::new(),
-            changes_json: String::new(),
+            change_views: vec![],
         }
         .render()
         .unwrap(),

--- a/src/routes/queue.rs
+++ b/src/routes/queue.rs
@@ -139,6 +139,376 @@ fn queue_type_icon_class(entry: &SubmissionListRow) -> &'static str {
     }
 }
 
+fn change_value_is_meaningful(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::String(s) => !s.trim().is_empty(),
+        serde_json::Value::Array(values) => !values.is_empty(),
+        serde_json::Value::Object(map) => {
+            !map.is_empty() && map.values().any(change_value_is_meaningful)
+        }
+        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => true,
+    }
+}
+
+fn change_field_label(field: &str) -> String {
+    match field {
+        "system_code" => "System".to_string(),
+        "media_type" => "Media".to_string(),
+        "category" => "Category".to_string(),
+        "title" => "Title".to_string(),
+        "title_foreign" => "Foreign Title".to_string(),
+        "disc_number" => "Disc Number".to_string(),
+        "disc_title" => "Disc Title".to_string(),
+        "filename_suffix" => "Filename Suffix".to_string(),
+        "regions" => "Region".to_string(),
+        "languages" => "Language".to_string(),
+        "serial" => "Serial".to_string(),
+        "version" => "Version".to_string(),
+        "edition" => "Edition".to_string(),
+        "barcode" => "Barcode".to_string(),
+        "exe_date" => "EXE Date".to_string(),
+        "error_count" => "Error Count".to_string(),
+        "edc" => "EDC".to_string(),
+        "disc_id" => "Disc ID".to_string(),
+        "disc_key" => "Disc Key".to_string(),
+        "universal_hash" => "Universal Hash".to_string(),
+        "comments" => "Comments".to_string(),
+        "protection" => "Protection".to_string(),
+        "sector_ranges" => "Sector Ranges".to_string(),
+        "sbi" => "SBI".to_string(),
+        "contents" => "Contents".to_string(),
+        "layerbreaks" => "Layerbreaks".to_string(),
+        "ring_codes" => "Rings".to_string(),
+        "pvd" => "PVD".to_string(),
+        "header" => "Header".to_string(),
+        "bca" => "BCA".to_string(),
+        "pic" => "PIC".to_string(),
+        "cuesheet" => "Cue Sheet".to_string(),
+        "dat" => "Files XML".to_string(),
+        other => other.replace('_', " "),
+    }
+}
+
+fn operation_inner<'a>(
+    operation: &'a serde_json::Value,
+    object_key: &str,
+    direct_key: &str,
+) -> Option<&'a serde_json::Value> {
+    operation
+        .get(object_key)
+        .and_then(|value| value.get(direct_key))
+        .or_else(|| operation.get(object_key))
+}
+
+fn direct_change_value<'a>(
+    operation: &'a serde_json::Value,
+    key: &str,
+) -> Option<&'a serde_json::Value> {
+    operation
+        .get(key)
+        .filter(|value| change_value_is_meaningful(value))
+}
+
+fn display_change_value(value: &serde_json::Value) -> String {
+    review_annotation_value(value)
+}
+
+fn empty_ring_change_cell() -> SubmissionRingChangeCell {
+    SubmissionRingChangeCell {
+        value: String::new(),
+        status_class: String::new(),
+    }
+}
+
+fn operation_status_value(operation: &serde_json::Value) -> Option<(&'static str, String)> {
+    if let Some(value) = operation_inner(operation, "modify", "new") {
+        return Some(("item-changed", display_change_value(value)));
+    }
+    if let Some(value) = operation_inner(operation, "add", "new") {
+        return Some(("item-added", display_change_value(value)));
+    }
+    if let Some(value) = operation_inner(operation, "remove", "old") {
+        return Some(("item-removed", display_change_value(value)));
+    }
+    if let Some(value) = direct_change_value(operation, "new") {
+        return Some(("item-added", display_change_value(value)));
+    }
+    if let Some(value) = direct_change_value(operation, "old") {
+        return Some(("item-removed", display_change_value(value)));
+    }
+    None
+}
+
+fn ring_change_cell(value: Option<&serde_json::Value>) -> SubmissionRingChangeCell {
+    value
+        .and_then(operation_status_value)
+        .map(|(status_class, value)| SubmissionRingChangeCell {
+            value,
+            status_class: status_class.to_string(),
+        })
+        .unwrap_or_else(empty_ring_change_cell)
+}
+
+fn ring_layer_label(layer_index: usize, layer_count: usize) -> String {
+    if layer_index + 1 == layer_count {
+        "LS".to_string()
+    } else {
+        format!("L{layer_index}")
+    }
+}
+
+fn submission_ring_change_rows(
+    ring_changes: &serde_json::Value,
+) -> (Vec<SubmissionRingChangeRow>, bool) {
+    let Some(entries) = ring_changes.as_array() else {
+        return (Vec::new(), false);
+    };
+
+    let show_ring_layers = entries.iter().any(|entry| {
+        entry
+            .get("layers")
+            .and_then(|layers| layers.as_array())
+            .is_some_and(|layers| !layers.is_empty())
+    });
+    let mut rows = Vec::new();
+    let mut entry_num = 0usize;
+
+    for entry in entries {
+        let Some(entry_obj) = entry.as_object() else {
+            continue;
+        };
+
+        let mut layer_changes = entry_obj
+            .get("layers")
+            .and_then(|layers| layers.as_array())
+            .cloned()
+            .unwrap_or_default();
+        layer_changes.sort_by_key(|layer| {
+            layer
+                .get("index")
+                .and_then(|index| index.as_i64())
+                .unwrap_or_default()
+        });
+
+        let layer_count = if show_ring_layers {
+            layer_changes
+                .iter()
+                .filter_map(|layer| layer.get("index").and_then(|index| index.as_u64()))
+                .max()
+                .map(|index| index as usize + 2)
+                .unwrap_or(2)
+                .max(2)
+        } else {
+            1
+        };
+
+        let row_count = layer_changes.len().max(1);
+        entry_num += 1;
+        let offset = ring_change_cell(
+            entry_obj
+                .get("offset_value")
+                .or_else(|| entry_obj.get("offset")),
+        );
+        let comment = if entry_obj
+            .get("remove")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+            && entry_obj.len() <= 2
+        {
+            SubmissionRingChangeCell {
+                value: "(removed entry)".to_string(),
+                status_class: "item-removed".to_string(),
+            }
+        } else {
+            ring_change_cell(entry_obj.get("comment"))
+        };
+
+        if layer_changes.is_empty() {
+            rows.push(SubmissionRingChangeRow {
+                entry_num,
+                entry_rowspan: 1,
+                layer_label: if show_ring_layers {
+                    ring_layer_label(0, layer_count)
+                } else {
+                    String::new()
+                },
+                mastering_code: empty_ring_change_cell(),
+                mastering_sid: empty_ring_change_cell(),
+                toolstamps: empty_ring_change_cell(),
+                mould_sids: empty_ring_change_cell(),
+                additional_moulds: empty_ring_change_cell(),
+                offset,
+                comment,
+            });
+            continue;
+        }
+
+        for (idx, layer) in layer_changes.iter().enumerate() {
+            let layer_index = layer
+                .get("index")
+                .and_then(|index| index.as_u64())
+                .map(|index| index as usize)
+                .unwrap_or(idx);
+            rows.push(SubmissionRingChangeRow {
+                entry_num,
+                entry_rowspan: if idx == 0 { row_count } else { 0 },
+                layer_label: ring_layer_label(layer_index, layer_count),
+                mastering_code: ring_change_cell(layer.get("mastering_code")),
+                mastering_sid: ring_change_cell(layer.get("mastering_sid")),
+                toolstamps: ring_change_cell(layer.get("toolstamps")),
+                mould_sids: ring_change_cell(layer.get("mould_sids")),
+                additional_moulds: ring_change_cell(layer.get("additional_moulds")),
+                offset: if idx == 0 {
+                    offset.clone()
+                } else {
+                    empty_ring_change_cell()
+                },
+                comment: if idx == 0 {
+                    comment.clone()
+                } else {
+                    empty_ring_change_cell()
+                },
+            });
+        }
+    }
+
+    (rows, show_ring_layers)
+}
+
+fn push_change_detail(
+    details: &mut Vec<SubmissionChangeDetail>,
+    field: &str,
+    current_value: String,
+    previous_value: String,
+) {
+    push_labeled_change_detail(
+        details,
+        field,
+        current_value,
+        previous_value,
+        String::new(),
+        "Changed from".to_string(),
+        String::new(),
+        "removed".to_string(),
+    );
+}
+
+fn push_labeled_change_detail(
+    details: &mut Vec<SubmissionChangeDetail>,
+    field: &str,
+    current_value: String,
+    previous_value: String,
+    current_label: String,
+    previous_label: String,
+    current_kind: String,
+    previous_kind: String,
+) {
+    if current_value.trim().is_empty() && previous_value.trim().is_empty() {
+        return;
+    }
+    let is_multiline = current_value.contains('\n') || previous_value.contains('\n');
+    details.push(SubmissionChangeDetail {
+        label: change_field_label(field),
+        current_value,
+        previous_value,
+        is_multiline,
+        current_label,
+        previous_label,
+        current_kind,
+        previous_kind,
+        ring_rows: Vec::new(),
+        show_ring_layers: false,
+    });
+}
+
+fn submission_change_details(changes: &serde_json::Value) -> Vec<SubmissionChangeDetail> {
+    let Some(changes) = changes.as_object() else {
+        return Vec::new();
+    };
+
+    let mut details = Vec::new();
+    for (field, change) in changes {
+        if !change_value_is_meaningful(change) {
+            continue;
+        }
+
+        if field == "ring_codes" {
+            let (ring_rows, show_ring_layers) = submission_ring_change_rows(change);
+            if !ring_rows.is_empty() {
+                details.push(SubmissionChangeDetail {
+                    label: change_field_label(field),
+                    current_value: String::new(),
+                    previous_value: String::new(),
+                    is_multiline: false,
+                    current_label: String::new(),
+                    previous_label: String::new(),
+                    current_kind: String::new(),
+                    previous_kind: String::new(),
+                    ring_rows,
+                    show_ring_layers,
+                });
+                continue;
+            }
+        }
+
+        if let Some(new_value) =
+            direct_change_value(change, "new").or_else(|| operation_inner(change, "modify", "new"))
+        {
+            let previous_value = direct_change_value(change, "old")
+                .or_else(|| operation_inner(change, "modify", "old"))
+                .map(display_change_value)
+                .unwrap_or_default();
+            push_change_detail(
+                &mut details,
+                field,
+                display_change_value(new_value),
+                previous_value,
+            );
+            continue;
+        }
+
+        if let Some(old_value) = direct_change_value(change, "old") {
+            push_change_detail(
+                &mut details,
+                field,
+                "(removed)".to_string(),
+                display_change_value(old_value),
+            );
+            continue;
+        }
+
+        let added =
+            operation_inner(change, "add", "new").filter(|value| change_value_is_meaningful(value));
+        let removed = operation_inner(change, "remove", "old")
+            .filter(|value| change_value_is_meaningful(value));
+        if added.is_some() || removed.is_some() {
+            let current_value = added.map(display_change_value).unwrap_or_default();
+            let previous_value = removed.map(display_change_value).unwrap_or_default();
+            push_labeled_change_detail(
+                &mut details,
+                field,
+                current_value,
+                previous_value,
+                "Added".to_string(),
+                "Removed".to_string(),
+                "added".to_string(),
+                "removed".to_string(),
+            );
+            continue;
+        }
+
+        push_change_detail(
+            &mut details,
+            field,
+            display_change_value(change),
+            String::new(),
+        );
+    }
+
+    details
+}
+
 #[derive(sqlx::FromRow)]
 struct SysRow {
     code: String,
@@ -2386,6 +2756,8 @@ mod tests {
             submission_type,
             display_kind,
             title: "Test Game".to_string(),
+            submission_comment: String::new(),
+            change_details: Vec::new(),
             system_code: "DVD".to_string(),
             system_display: "DVD".to_string(),
             submitter: "submitter".to_string(),
@@ -2451,6 +2823,45 @@ mod tests {
         assert_eq!(normalize_queue_sort(Some("DISC_ID")), "disc_id");
         assert_eq!(normalize_queue_order(Some("ASC")), "asc");
         assert_eq!(normalize_queue_order(Some("DESC")), "desc");
+    }
+
+    #[test]
+    fn history_change_details_extract_current_and_previous_values() {
+        let details = submission_change_details(&serde_json::json!({
+            "title": { "modify": { "old": "Old", "new": "New" } },
+            "regions": { "add": ["Japan"] },
+            "serial": { "remove": ["OLD-001"], "add": ["NEW-001"] },
+            "dat": { "modify": { "old": "<old />", "new": "<new />\n<new2 />" } },
+            "custom_field": { "add": { "new": "custom" } },
+            "comments": { "old": "old comment", "new": "new comment" },
+            "ring_codes": { "new": "SLPS-02110\t1 IFPI L275" }
+        }));
+
+        let mut changes: Vec<(&str, &str, &str, bool)> = details
+            .iter()
+            .map(|change| {
+                (
+                    change.label.as_str(),
+                    change.current_value.as_str(),
+                    change.previous_value.as_str(),
+                    change.is_multiline,
+                )
+            })
+            .collect();
+        changes.sort_by_key(|change| change.0.to_string());
+
+        assert_eq!(
+            changes,
+            vec![
+                ("Comments", "new comment", "old comment", false),
+                ("Files XML", "<new />\n<new2 />", "<old />", true),
+                ("Region", "Japan", "", false),
+                ("Rings", "SLPS-02110\t1 IFPI L275", "", false),
+                ("Serial", "NEW-001", "OLD-001", false),
+                ("Title", "New", "Old", false),
+                ("custom field", "custom", "", false),
+            ]
+        );
     }
 
     #[tokio::test]
@@ -3020,6 +3431,7 @@ impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for SubmissionListRow {
         use sqlx::Row;
         let submission_type: SubmissionType = row.try_get("submission_type")?;
         let submission_has_dat_add: bool = row.try_get("submission_has_dat_add")?;
+        let changes_summary: serde_json::Value = row.try_get("changes_summary")?;
         let system_code: String = row.try_get("system_code")?;
         let system_short_name: Option<String> = row.try_get("system_short_name").ok();
         let system_display = crate::db::models::short_system_display(
@@ -3034,6 +3446,8 @@ impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for SubmissionListRow {
                 submission_has_dat_add,
             ),
             title: row.try_get("title")?,
+            submission_comment: row.try_get("submission_comment")?,
+            change_details: submission_change_details(&changes_summary),
             system_code,
             system_display,
             submitter: row.try_get("submitter")?,

--- a/src/routes/queue.rs
+++ b/src/routes/queue.rs
@@ -1,13 +1,14 @@
 use askama::Template;
 use axum::{
+    Router,
     extract::{Path, Query, State},
     response::{Html, IntoResponse, Redirect, Response},
     routing::{get, post},
-    Router,
 };
 use axum_extra::extract::Form;
 use serde::Deserialize;
 
+use crate::AppState;
 use crate::auth::{
     csrf,
     middleware::{AuthenticatedUser, CurrentUser, RequireAuth},
@@ -16,15 +17,14 @@ use crate::config::SiteConfig;
 use crate::db::models::*;
 use crate::error::{AppError, AppResult};
 use crate::services::{disc_service, queue_service};
-use crate::AppState;
 
 use super::disc_edit::{
-    self, approval_conflicts_to_linked_validation_errors, build_category_options,
-    build_check_options, build_flat_changes, build_lang_check_options, build_media_has_pic_json,
-    build_media_is_cd_json, build_media_layers_json, build_media_options,
-    build_media_rom_extensions_json, build_new_disc_changes, build_sparse_edit_changes,
-    build_system_options, build_systems_json, fetch_ref_data, max_layers_for_media, validate_form,
-    DiscEditForm, DiscEditTemplate, ReviewAnnotation, ReviewOldMultiline,
+    self, DiscEditForm, DiscEditTemplate, ReviewAnnotation, ReviewOldMultiline,
+    approval_conflicts_to_linked_validation_errors, build_category_options, build_check_options,
+    build_flat_changes, build_lang_check_options, build_media_has_pic_json, build_media_is_cd_json,
+    build_media_layers_json, build_media_options, build_media_rom_extensions_json,
+    build_new_disc_changes, build_sparse_edit_changes, build_system_options, build_systems_json,
+    fetch_ref_data, max_layers_for_media, validate_form,
 };
 
 fn normalize_newlines(s: &str) -> String {
@@ -173,6 +173,7 @@ fn change_field_label(field: &str) -> String {
         "disc_id" => "Disc ID".to_string(),
         "disc_key" => "Disc Key".to_string(),
         "universal_hash" => "Universal Hash".to_string(),
+        "status" => "Status".to_string(),
         "comments" => "Comments".to_string(),
         "protection" => "Protection".to_string(),
         "sector_ranges" => "Sector Ranges".to_string(),
@@ -212,6 +213,339 @@ fn direct_change_value<'a>(
 
 fn display_change_value(value: &serde_json::Value) -> String {
     review_annotation_value(value)
+}
+
+fn friendly_json_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Array(values) => values
+            .iter()
+            .map(friendly_json_value)
+            .filter(|s| !s.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join(", "),
+        serde_json::Value::Object(map) => {
+            if let (Some(start), Some(end)) = (map.get("start"), map.get("end")) {
+                return format!(
+                    "{}-{}",
+                    friendly_json_value(start),
+                    friendly_json_value(end)
+                );
+            }
+            map.iter()
+                .map(|(key, value)| format!("{key}: {}", friendly_json_value(value)))
+                .collect::<Vec<_>>()
+                .join("; ")
+        }
+    }
+}
+
+fn empty_display_value(value: String) -> String {
+    if value.trim().is_empty() {
+        "(empty)".to_string()
+    } else {
+        value
+    }
+}
+
+fn status_for_action(action: &str) -> &'static str {
+    match action {
+        "Added" => "item-added",
+        "Removed" => "item-removed",
+        "Modified" => "item-changed",
+        _ => "",
+    }
+}
+
+fn change_operation_parts(
+    change: &serde_json::Value,
+) -> Option<(
+    &'static str,
+    Option<&serde_json::Value>,
+    Option<&serde_json::Value>,
+)> {
+    if let Some(modify) = change.get("modify") {
+        return Some(("Modified", modify.get("old"), modify.get("new")));
+    }
+    if let Some(add) = change.get("add") {
+        return Some(("Added", None, add.get("new").or(Some(add))));
+    }
+    if let Some(remove) = change.get("remove") {
+        return Some(("Removed", remove.get("old").or(Some(remove)), None));
+    }
+    match (change.get("old"), change.get("new")) {
+        (Some(old), Some(new)) => Some(("Modified", Some(old), Some(new))),
+        (None, Some(new)) => Some(("Added", None, Some(new))),
+        (Some(old), None) => Some(("Removed", Some(old), None)),
+        (None, None) => None,
+    }
+}
+
+fn change_scalar_row(field: &str, change: &serde_json::Value) -> Option<SubmissionChangeScalarRow> {
+    let (action, old, new) = change_operation_parts(change)?;
+    Some(SubmissionChangeScalarRow {
+        field: change_field_label(field),
+        action: action.to_string(),
+        previous_value: old
+            .map(friendly_json_value)
+            .map(empty_display_value)
+            .unwrap_or_default(),
+        current_value: new
+            .map(friendly_json_value)
+            .map(empty_display_value)
+            .unwrap_or_default(),
+        status_class: status_for_action(action).to_string(),
+    })
+}
+
+fn change_multiline_row(
+    field: &str,
+    change: &serde_json::Value,
+) -> Option<SubmissionChangeMultilineRow> {
+    let (action, old, new) = change_operation_parts(change)?;
+    Some(SubmissionChangeMultilineRow {
+        field: change_field_label(field),
+        action: action.to_string(),
+        previous_value: old.map(friendly_json_value).unwrap_or_default(),
+        current_value: new.map(friendly_json_value).unwrap_or_default(),
+        status_class: status_for_action(action).to_string(),
+    })
+}
+
+fn string_vec_values(value: Option<&serde_json::Value>) -> Vec<String> {
+    match value {
+        Some(serde_json::Value::Array(values)) => values
+            .iter()
+            .map(friendly_json_value)
+            .filter(|s| !s.trim().is_empty())
+            .collect(),
+        Some(value) => {
+            let display = friendly_json_value(value);
+            if display.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![display]
+            }
+        }
+        None => Vec::new(),
+    }
+}
+
+fn change_set_row(field: &str, change: &serde_json::Value) -> Option<SubmissionChangeSetRow> {
+    let added = string_vec_values(
+        change
+            .get("add")
+            .and_then(|value| value.get("new"))
+            .or_else(|| change.get("add")),
+    );
+    let removed = string_vec_values(
+        change
+            .get("remove")
+            .and_then(|value| value.get("old"))
+            .or_else(|| change.get("remove")),
+    );
+    if added.is_empty() && removed.is_empty() {
+        None
+    } else {
+        Some(SubmissionChangeSetRow {
+            field: change_field_label(field),
+            added,
+            removed,
+        })
+    }
+}
+
+fn push_fallback_rows(
+    rows: &mut Vec<SubmissionChangeFallbackRow>,
+    path: String,
+    value: &serde_json::Value,
+) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.is_empty() {
+                rows.push(SubmissionChangeFallbackRow {
+                    path,
+                    value: "(empty object)".to_string(),
+                });
+                return;
+            }
+            for (key, child) in map {
+                let child_path = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{path}.{key}")
+                };
+                push_fallback_rows(rows, child_path, child);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            if values.is_empty() {
+                rows.push(SubmissionChangeFallbackRow {
+                    path,
+                    value: "(empty list)".to_string(),
+                });
+                return;
+            }
+            for (idx, child) in values.iter().enumerate() {
+                push_fallback_rows(rows, format!("{path}[{idx}]"), child);
+            }
+        }
+        _ => rows.push(SubmissionChangeFallbackRow {
+            path,
+            value: empty_display_value(friendly_json_value(value)),
+        }),
+    }
+}
+
+fn add_change_fallback(view: &mut SubmissionChangesView, field: &str, change: &serde_json::Value) {
+    push_fallback_rows(&mut view.fallback_rows, change_field_label(field), change);
+}
+
+fn change_view_has_content(view: &SubmissionChangesView) -> bool {
+    !view.scalar_rows.is_empty()
+        || !view.set_rows.is_empty()
+        || !view.multiline_rows.is_empty()
+        || !view.legacy_rows.is_empty()
+        || !view.ring_sections.is_empty()
+        || !view.fallback_rows.is_empty()
+}
+
+fn is_multiline_change_field(field: &str) -> bool {
+    matches!(
+        field,
+        "comments"
+            | "contents"
+            | "protection"
+            | "sector_ranges"
+            | "sbi"
+            | "layerbreaks"
+            | "pvd"
+            | "header"
+            | "bca"
+            | "pic"
+            | "cuesheet"
+            | "dat"
+    )
+}
+
+fn is_set_change_field(field: &str) -> bool {
+    matches!(
+        field,
+        "regions" | "languages" | "serial" | "edition" | "barcode"
+    )
+}
+
+fn build_submission_changes_view(
+    title: &str,
+    note: &str,
+    changes: &serde_json::Value,
+) -> SubmissionChangesView {
+    let mut view = SubmissionChangesView {
+        title: title.to_string(),
+        note: note.to_string(),
+        has_changes: false,
+        scalar_rows: Vec::new(),
+        set_rows: Vec::new(),
+        multiline_rows: Vec::new(),
+        legacy_rows: Vec::new(),
+        ring_sections: Vec::new(),
+        fallback_rows: Vec::new(),
+    };
+
+    let Some(obj) = changes.as_object() else {
+        add_change_fallback(&mut view, "changes", changes);
+        view.has_changes = change_view_has_content(&view);
+        return view;
+    };
+
+    for (field, change) in obj {
+        if field == "legacy" {
+            if let Some(legacy_obj) = change.as_object() {
+                for (legacy_field, legacy_change) in legacy_obj {
+                    if let Some(row) = change_scalar_row(legacy_field, legacy_change) {
+                        view.legacy_rows.push(row);
+                    } else {
+                        push_fallback_rows(
+                            &mut view.fallback_rows,
+                            format!("Legacy.{}", change_field_label(legacy_field)),
+                            legacy_change,
+                        );
+                    }
+                }
+            } else {
+                add_change_fallback(&mut view, field, change);
+            }
+            continue;
+        }
+
+        if field == "ring_codes" && change.as_array().is_some() {
+            let (ring_rows, show_ring_layers) = submission_ring_change_rows(change);
+            if !ring_rows.is_empty() {
+                view.ring_sections.push(SubmissionChangeRingSection {
+                    label: change_field_label(field),
+                    ring_rows,
+                    show_ring_layers,
+                });
+            } else {
+                add_change_fallback(&mut view, field, change);
+            }
+            continue;
+        }
+
+        if is_set_change_field(field) {
+            if let Some(row) = change_set_row(field, change) {
+                view.set_rows.push(row);
+                continue;
+            }
+        }
+
+        if is_multiline_change_field(field) {
+            if let Some(row) = change_multiline_row(field, change) {
+                view.multiline_rows.push(row);
+                continue;
+            }
+        }
+
+        if let Some(row) = change_scalar_row(field, change) {
+            view.scalar_rows.push(row);
+        } else {
+            add_change_fallback(&mut view, field, change);
+        }
+    }
+
+    view.has_changes = change_view_has_content(&view);
+    view
+}
+
+fn submission_changes_views(
+    original: Option<&serde_json::Value>,
+    final_changes: &serde_json::Value,
+) -> Vec<SubmissionChangesView> {
+    match original.filter(|value| !value.is_null()) {
+        Some(original) => {
+            let mut views = vec![build_submission_changes_view(
+                "Submitted Changes",
+                "",
+                original,
+            )];
+            if original != final_changes {
+                views.push(build_submission_changes_view(
+                    "Final Approved Changes",
+                    "Includes reviewer edits made before approval.",
+                    final_changes,
+                ));
+            }
+            views
+        }
+        None => vec![build_submission_changes_view(
+            "Submitted / Current Changes",
+            "",
+            final_changes,
+        )],
+    }
 }
 
 fn empty_ring_change_cell() -> SubmissionRingChangeCell {
@@ -310,6 +644,12 @@ fn submission_ring_change_rows(
                 .get("offset_value")
                 .or_else(|| entry_obj.get("offset")),
         );
+        let offset_extra = ring_change_cell(entry_obj.get("offset_extra_value"));
+        let sample_start = ring_change_cell(
+            entry_obj
+                .get("sample_data_start")
+                .or_else(|| entry_obj.get("sample_start")),
+        );
         let comment = if entry_obj
             .get("remove")
             .and_then(|value| value.as_bool())
@@ -339,6 +679,8 @@ fn submission_ring_change_rows(
                 mould_sids: empty_ring_change_cell(),
                 additional_moulds: empty_ring_change_cell(),
                 offset,
+                offset_extra,
+                sample_start,
                 comment,
             });
             continue;
@@ -361,6 +703,16 @@ fn submission_ring_change_rows(
                 additional_moulds: ring_change_cell(layer.get("additional_moulds")),
                 offset: if idx == 0 {
                     offset.clone()
+                } else {
+                    empty_ring_change_cell()
+                },
+                offset_extra: if idx == 0 {
+                    offset_extra.clone()
+                } else {
+                    empty_ring_change_cell()
+                },
+                sample_start: if idx == 0 {
+                    sample_start.clone()
                 } else {
                     empty_ring_change_cell()
                 },
@@ -1143,8 +1495,7 @@ fn build_review_template(
             .reviewed_at
             .map(|t| t.format("%Y-%m-%d %H:%M UTC").to_string())
             .unwrap_or_default(),
-        changes_original_json: pretty_optional_json(sub.changes_original.as_ref()),
-        changes_json: serde_json::to_string_pretty(&sub.changes).unwrap_or_default(),
+        change_views: submission_changes_views(sub.changes_original.as_ref(), &sub.changes),
     }
 }
 
@@ -1689,17 +2040,9 @@ struct QueueDetailTemplate {
     created_at_display: String,
     reviewed_at_display: String,
     target_disc_id: i32,
-    changes_original_json: String,
-    changes_json: String,
+    change_views: Vec<SubmissionChangesView>,
 }
 impl SiteConfig for QueueDetailTemplate {}
-
-fn pretty_optional_json(value: Option<&serde_json::Value>) -> String {
-    match value {
-        Some(value) if !value.is_null() => serde_json::to_string_pretty(value).unwrap_or_default(),
-        _ => String::new(),
-    }
-}
 
 async fn render_readonly_detail(
     current_user: Option<AuthenticatedUser>,
@@ -1726,8 +2069,7 @@ async fn render_readonly_detail(
             .map(|t| t.format("%Y-%m-%d %H:%M UTC").to_string())
             .unwrap_or_default(),
         target_disc_id: sub.target_disc_id.unwrap_or(0),
-        changes_original_json: pretty_optional_json(sub.changes_original.as_ref()),
-        changes_json: serde_json::to_string_pretty(&sub.changes).unwrap_or_default(),
+        change_views: submission_changes_views(sub.changes_original.as_ref(), &sub.changes),
     };
 
     Ok(Html(template.render().unwrap()))
@@ -3071,8 +3413,7 @@ mod tests {
             created_at_display: "2026-01-01 00:00 UTC".to_string(),
             reviewed_at_display: String::new(),
             target_disc_id: 3,
-            changes_original_json: String::new(),
-            changes_json: "{}".to_string(),
+            change_views: submission_changes_views(None, &serde_json::json!({})),
         };
 
         let html = template.render().unwrap();
@@ -3081,7 +3422,7 @@ mod tests {
     }
 
     #[test]
-    fn queue_detail_template_shows_original_json_before_final_json() {
+    fn queue_detail_template_shows_submitted_changes_before_final_changes() {
         let template = QueueDetailTemplate {
             current_user: None,
             submission_id: 1,
@@ -3098,31 +3439,175 @@ mod tests {
             created_at_display: "2026-01-01 00:00 UTC".to_string(),
             reviewed_at_display: "2026-01-02 00:00 UTC".to_string(),
             target_disc_id: 3,
-            changes_original_json: "{\n  \"status\": \"original\"\n}".to_string(),
-            changes_json: "{\n  \"status\": \"final\"\n}".to_string(),
+            change_views: submission_changes_views(
+                Some(
+                    &serde_json::json!({ "status": { "modify": { "old": "Unverified", "new": "Verified" } } }),
+                ),
+                &serde_json::json!({ "status": { "modify": { "old": "Unverified", "new": "Disabled" } } }),
+            ),
         };
 
         let html = template.render().unwrap();
 
-        let original_pos = html.find("Original JSON").unwrap();
-        let final_pos = html.find("Final JSON").unwrap();
+        let original_pos = html.find("Submitted Changes").unwrap();
+        let final_pos = html.find("Final Approved Changes").unwrap();
         assert!(original_pos < final_pos);
-        assert!(!html.contains("Raw JSON"));
+        assert!(html.contains("Includes reviewer edits made before approval."));
+        assert!(!html.contains("raw-json"));
     }
 
     #[test]
-    fn review_template_shows_final_json_without_original_json_when_absent() {
+    fn review_template_shows_current_changes_without_original_when_absent() {
         let html = build_template(&submitted_snapshot()).render().unwrap();
 
-        assert!(!html.contains("Original JSON"));
-        assert!(html.contains("Final JSON"));
-        assert!(!html.contains("Raw JSON"));
+        assert!(!html.contains("Submitted Changes"));
+        assert!(html.contains("Submitted / Current Changes"));
+        assert!(!html.contains("raw-json"));
     }
 
     #[test]
-    fn changes_original_json_hides_none_and_json_null() {
-        assert_eq!(pretty_optional_json(None), "");
-        assert_eq!(pretty_optional_json(Some(&serde_json::Value::Null)), "");
+    fn submission_change_views_ignore_null_original() {
+        let views =
+            submission_changes_views(Some(&serde_json::Value::Null), &serde_json::json!({}));
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].title, "Submitted / Current Changes");
+    }
+
+    #[test]
+    fn submission_change_view_renders_scalar_set_multiline_and_fallback_rows() {
+        let changes = serde_json::json!({
+            "title": { "modify": { "old": "Old Title", "new": "New Title" } },
+            "version": { "add": { "new": "1.01" } },
+            "error_count": { "remove": { "old": 2 } },
+            "regions": { "add": ["Japan", "USA"], "remove": ["Europe"] },
+            "serial": { "add": { "new": ["SLUS-00001"] }, "remove": { "old": ["OLD-00001"] } },
+            "comments": { "modify": { "old": "old\ncomment", "new": "new\ncomment" } },
+            "dat": { "add": { "new": "<rom name=\"track.bin\" />" } },
+            "layerbreaks": { "modify": { "old": [12345], "new": [23456] } },
+            "future_shape": { "deep": [{ "value": true }] }
+        });
+
+        let view = build_submission_changes_view("Test Changes", "", &changes);
+
+        assert!(view.has_changes);
+        assert!(view.scalar_rows.iter().any(|row| {
+            row.field == "Title"
+                && row.action == "Modified"
+                && row.previous_value == "Old Title"
+                && row.current_value == "New Title"
+        }));
+        assert!(view.scalar_rows.iter().any(|row| {
+            row.field == "Version" && row.action == "Added" && row.current_value == "1.01"
+        }));
+        assert!(view.scalar_rows.iter().any(|row| {
+            row.field == "Error Count" && row.action == "Removed" && row.previous_value == "2"
+        }));
+        assert!(view.set_rows.iter().any(|row| {
+            row.field == "Region"
+                && row.added == vec!["Japan".to_string(), "USA".to_string()]
+                && row.removed == vec!["Europe".to_string()]
+        }));
+        assert!(view.set_rows.iter().any(|row| {
+            row.field == "Serial"
+                && row.added == vec!["SLUS-00001".to_string()]
+                && row.removed == vec!["OLD-00001".to_string()]
+        }));
+        assert!(view.multiline_rows.iter().any(|row| {
+            row.field == "Comments"
+                && row.previous_value == "old\ncomment"
+                && row.current_value == "new\ncomment"
+        }));
+        assert!(view.multiline_rows.iter().any(|row| {
+            row.field == "Files XML" && row.current_value == "<rom name=\"track.bin\" />"
+        }));
+        assert!(view.multiline_rows.iter().any(|row| {
+            row.field == "Layerbreaks"
+                && row.previous_value == "12345"
+                && row.current_value == "23456"
+        }));
+        assert!(
+            view.fallback_rows
+                .iter()
+                .any(|row| { row.path == "future shape.deep[0].value" && row.value == "true" })
+        );
+    }
+
+    #[test]
+    fn submission_change_view_renders_ring_and_legacy_changes() {
+        let changes = serde_json::json!({
+            "ring_codes": [
+                {
+                    "layers": [
+                        {
+                            "index": 0,
+                            "mastering_code": { "modify": { "old": "OLD-MC", "new": "NEW-MC" } },
+                            "toolstamps": { "add": { "new": "T1" } }
+                        }
+                    ],
+                    "offset": { "modify": { "old": "0", "new": "-12" } },
+                    "offset_extra_value": { "modify": { "old": "1", "new": "2" } },
+                    "sample_data_start": { "modify": { "old": "100", "new": "200" } },
+                    "comment": { "add": { "new": "Local history display test comment" } }
+                },
+                { "remove": true }
+            ],
+            "legacy": {
+                "serial": { "old": "SLPS-00001", "new": "SLPS 00001" },
+                "unmapped_blob": { "nested": "value" }
+            }
+        });
+
+        let view = build_submission_changes_view("Test Changes", "", &changes);
+
+        assert_eq!(view.ring_sections.len(), 1);
+        let ring = &view.ring_sections[0];
+        assert!(ring.show_ring_layers);
+        assert_eq!(ring.ring_rows.len(), 2);
+        assert_eq!(ring.ring_rows[0].mastering_code.value, "NEW-MC");
+        assert_eq!(
+            ring.ring_rows[0].mastering_code.status_class,
+            "item-changed"
+        );
+        assert_eq!(ring.ring_rows[0].toolstamps.value, "T1");
+        assert_eq!(ring.ring_rows[0].toolstamps.status_class, "item-added");
+        assert_eq!(ring.ring_rows[0].offset.value, "-12");
+        assert_eq!(ring.ring_rows[0].offset_extra.value, "2");
+        assert_eq!(ring.ring_rows[0].offset_extra.status_class, "item-changed");
+        assert_eq!(ring.ring_rows[0].sample_start.value, "200");
+        assert_eq!(ring.ring_rows[0].sample_start.status_class, "item-changed");
+        assert_eq!(
+            ring.ring_rows[0].comment.value,
+            "Local history display test comment"
+        );
+        assert_eq!(ring.ring_rows[1].comment.value, "(removed entry)");
+        assert_eq!(ring.ring_rows[1].comment.status_class, "item-removed");
+        assert!(view.legacy_rows.iter().any(|row| {
+            row.field == "Serial"
+                && row.previous_value == "SLPS-00001"
+                && row.current_value == "SLPS 00001"
+        }));
+        assert!(
+            view.fallback_rows
+                .iter()
+                .any(|row| { row.path == "Legacy.unmapped blob.nested" && row.value == "value" })
+        );
+    }
+
+    #[test]
+    fn submission_change_views_skip_final_panel_when_original_matches_final() {
+        let changes = serde_json::json!({
+            "status": { "modify": { "old": "Unverified", "new": "Verified" } }
+        });
+
+        let views = submission_changes_views(Some(&changes), &changes);
+
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].title, "Submitted Changes");
+        assert!(views[0].scalar_rows.iter().any(|row| {
+            row.field == "Status"
+                && row.previous_value == "Unverified"
+                && row.current_value == "Verified"
+        }));
     }
 
     #[test]
@@ -3295,22 +3780,30 @@ mod tests {
             annotation_values(&template, "universal_hash", "Changed from"),
             vec!["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()]
         );
-        assert!(template
-            .review_old_multiline
-            .iter()
-            .any(|old| old.field == "contents" && old.value == "old contents"));
-        assert!(template
-            .review_old_multiline
-            .iter()
-            .any(|old| old.field == "cue" && old.value == "old cue"));
-        assert!(template
-            .review_old_multiline
-            .iter()
-            .any(|old| { old.field == "files_xml" && old.value.contains("old.iso") }));
-        assert!(!template
-            .review_old_multiline
-            .iter()
-            .any(|old| old.field == "comments"));
+        assert!(
+            template
+                .review_old_multiline
+                .iter()
+                .any(|old| old.field == "contents" && old.value == "old contents")
+        );
+        assert!(
+            template
+                .review_old_multiline
+                .iter()
+                .any(|old| old.field == "cue" && old.value == "old cue")
+        );
+        assert!(
+            template
+                .review_old_multiline
+                .iter()
+                .any(|old| { old.field == "files_xml" && old.value.contains("old.iso") })
+        );
+        assert!(
+            !template
+                .review_old_multiline
+                .iter()
+                .any(|old| old.field == "comments")
+        );
     }
 
     #[test]
@@ -3358,22 +3851,28 @@ mod tests {
         submitted["universal_hash"] = serde_json::json!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
         let highlights = compute_field_highlights(&submitted, &db);
-        assert!(highlights
-            .changed_fields
-            .contains(&"universal_hash:changed".to_string()));
+        assert!(
+            highlights
+                .changed_fields
+                .contains(&"universal_hash:changed".to_string())
+        );
 
         db["universal_hash"] = serde_json::Value::Null;
         let highlights = compute_field_highlights(&submitted, &db);
-        assert!(highlights
-            .changed_fields
-            .contains(&"universal_hash:added".to_string()));
+        assert!(
+            highlights
+                .changed_fields
+                .contains(&"universal_hash:added".to_string())
+        );
 
         db["universal_hash"] = serde_json::json!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         submitted["universal_hash"] = serde_json::Value::Null;
         let highlights = compute_field_highlights(&submitted, &db);
-        assert!(highlights
-            .changed_fields
-            .contains(&"universal_hash:removed".to_string()));
+        assert!(
+            highlights
+                .changed_fields
+                .contains(&"universal_hash:removed".to_string())
+        );
     }
 
     #[test]
@@ -3388,7 +3887,9 @@ mod tests {
     #[test]
     fn review_textarea_assets_autosize_sidecars_without_manual_resize_wrapper() {
         let css = include_str!("../../static/css/app.css");
-        assert!(css.contains("textarea.auto-expand {\n    overflow: hidden;\n    resize: none;\n}"));
+        assert!(
+            css.contains("textarea.auto-expand {\n    overflow: hidden;\n    resize: none;\n}")
+        );
         assert!(!css.contains("textarea-resize"));
         assert!(css.contains(".review-field-annotation {\n    flex: 0 0 100%;\n    width: 100%;\n    display: flex;\n    flex-wrap: nowrap;\n    align-items: center;\n    gap: 0.25rem;\n    overflow-x: auto;\n    white-space: nowrap;\n}"));
         assert!(

--- a/src/services/queue_service.rs
+++ b/src/services/queue_service.rs
@@ -1431,6 +1431,11 @@ pub async fn list_submissions(
     let system_expr = "CONCAT_WS(' ', NULLIF(s.manufacturer, ''), \
                        COALESCE(s.name, d.system_code, ds.changes->'system_code'->'add'->>'new', ds.changes->'system_code'->'modify'->>'new', ''))";
     let type_expr = submission_display_kind_sql();
+    let changes_summary_expr = if disc_id_filter.is_some() {
+        "ds.changes"
+    } else {
+        "'{}'::jsonb"
+    };
     let sort_col = match sort_column {
         "date" => "ds.created_at".to_string(),
         "title" => format!("LOWER({title_expr})"),
@@ -1453,6 +1458,8 @@ pub async fn list_submissions(
         "SELECT ds.id, ds.submission_type,
                 {dat_add_expr} AS submission_has_dat_add,
                 {title_expr} AS title,
+                COALESCE(ds.submission_comment, '') AS submission_comment,
+                {changes_summary_expr} AS changes_summary,
                 COALESCE(d.system_code, ds.changes->'system_code'->'add'->>'new', ds.changes->'system_code'->'modify'->>'new', '') AS system_code,
                 COALESCE(s.short_name, '') AS system_short_name,
                 u.username AS submitter,

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -860,7 +860,7 @@ nav[aria-label="Pagination"] ul {
     justify-content: center;
     align-items: start;
     gap: 0.5rem clamp(1.5rem, 4vw, 3.5rem);
-    margin-bottom: 2.5rem;
+    margin-bottom: 2rem;
 }
 .disc-view .disc-side-stack {
     display: contents;
@@ -2285,6 +2285,132 @@ table.striped tbody tr.clickable-row.is-row-hover td {
     width: 100%;
 }
 
+.disc-history-summary {
+    text-align: center;
+}
+
+.disc-history-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.05rem;
+    height: 1.05rem;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--pico-primary);
+    font-size: 0.9rem;
+    line-height: 1;
+    cursor: pointer;
+    flex: 0 0 1.05rem;
+}
+
+.disc-history-toggle::before {
+    content: "▶";
+    display: block;
+}
+
+.disc-history-toggle[aria-expanded="true"]::before {
+    content: "▼";
+}
+
+.disc-history-date-cell {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
+}
+
+.disc-history-changes-row > td {
+    padding: 0 0.35rem 0.55rem 2rem;
+}
+
+.disc-history-changes {
+    width: max-content;
+    min-width: 100%;
+    overflow-x: visible;
+    text-align: left;
+    white-space: normal;
+}
+
+.disc-history-submission-comment {
+    margin: 0.35rem 0;
+    padding: 0.35rem 0.5rem 0.45rem;
+    border-left: 3px solid var(--pico-primary);
+}
+
+.disc-history-submission-comment .section-text {
+    margin: 0.25rem 0 0;
+}
+
+.disc-history-change-detail {
+    display: grid;
+    grid-template-columns: 6.8rem minmax(12rem, 1fr);
+    column-gap: 0.35rem;
+    row-gap: 0.2rem;
+    align-items: flex-start;
+    margin: 0.35rem 0;
+}
+
+.disc-history-change-detail .inline-field-label {
+    padding-top: 0.2rem;
+}
+
+.disc-history-change-detail .inline-field-values {
+    min-width: 0;
+}
+
+.disc-history-change-detail input[readonly],
+.disc-history-change-detail textarea[readonly] {
+    max-width: 100%;
+    margin: 0;
+}
+
+.disc-history-change-detail input[readonly] {
+    width: min(42rem, 100%);
+}
+
+.disc-history-change-detail textarea[readonly] {
+    width: min(56rem, 100%);
+    resize: vertical;
+}
+
+.disc-history-multiline-detail {
+    margin: 0.35rem 0;
+    padding-top: 0.35rem;
+    padding-bottom: 0.45rem;
+}
+
+.disc-history-ring-detail {
+    margin: 0.35rem 0;
+    padding-top: 0.35rem;
+    padding-bottom: 0.4rem;
+}
+
+.disc-history-ring-label {
+    display: inline-block;
+    margin: 0 0 0.25rem 0.35rem;
+}
+
+.disc-history-ring-detail .table-scroll {
+    width: fit-content;
+    max-width: none;
+    margin: 0.1rem 0 0;
+    text-align: left;
+}
+
+.disc-history-ring-table input[readonly] {
+    cursor: default;
+}
+
+.disc-history-ring-table .ring-mc { width: 28ch; }
+.disc-history-ring-table .ring-ms { width: 16ch; }
+.disc-history-ring-table .ring-tools { width: 10ch; }
+.disc-history-ring-table .ring-moulds { width: 15ch; }
+.disc-history-ring-table .ring-addmoulds { width: 18ch; }
+.disc-history-ring-table .ring-offset { width: 6ch; }
+.disc-history-ring-table .ring-comment { width: 28ch; }
+
 .queue-table-scroll {
     width: 100%;
     text-align: center;
@@ -2298,10 +2424,26 @@ table.striped tbody tr.clickable-row.is-row-hover td {
     text-align: left;
 }
 
+.queue-history-table {
+    min-width: max-content;
+}
+
 .queue-table th,
 .queue-table td {
     white-space: nowrap;
     padding-inline-end: 0.75rem;
+}
+
+.queue-history-table th,
+.queue-history-table tbody > tr:not(.disc-history-changes-row) > td {
+    padding-top: 0.12rem;
+    padding-bottom: 0.12rem;
+    line-height: 1.15;
+    vertical-align: middle;
+}
+
+.queue-history-table tbody > tr:not(.disc-history-changes-row) > td {
+    height: 1.65rem;
 }
 
 .queue-table .submission-title-col {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2285,6 +2285,15 @@ table.striped tbody tr.clickable-row.is-row-hover td {
     width: 100%;
 }
 
+.queue-count {
+    text-align: center;
+    margin-bottom: 0.15rem;
+}
+
+.queue-count small {
+    font-size: 0.8rem;
+}
+
 .disc-history-summary {
     text-align: center;
 }
@@ -2409,6 +2418,8 @@ table.striped tbody tr.clickable-row.is-row-hover td {
 .disc-history-ring-table .ring-moulds { width: 15ch; }
 .disc-history-ring-table .ring-addmoulds { width: 18ch; }
 .disc-history-ring-table .ring-offset { width: 6ch; }
+.disc-history-ring-table .ring-offset-extra { width: 8ch; }
+.disc-history-ring-table .ring-sample-start { width: 9ch; }
 .disc-history-ring-table .ring-comment { width: 28ch; }
 
 .queue-table-scroll {
@@ -3652,38 +3663,102 @@ tr.field-changed > td { background-color: rgba(255, 235, 59, 0.18); }
     margin-left: auto;
     margin-right: auto;
 }
-.submission-info pre.raw-json {
-    box-sizing: border-box;
-    width: min(68rem, 100%);
-    max-height: none;
-    margin-left: auto;
-    margin-right: auto;
-    overflow: visible;
-    overflow-x: visible;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-size: 0.8rem;
-    border: var(--pico-border-width) solid var(--pico-form-element-border-color);
-    border-radius: var(--pico-border-radius);
-    background: var(--pico-code-background-color);
-    padding: 0.65rem 0.8rem;
-}
-.submission-info pre.raw-json code {
-    max-height: none;
-    overflow-y: visible;
-}
-.submission-info details {
+.submission-change-view {
     width: min(68rem, 100%);
     margin-top: 0.75rem;
     margin-left: auto;
     margin-right: auto;
 }
-.submission-info details > summary {
+.submission-change-view > summary {
     width: fit-content;
     margin-bottom: 0.25rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+.submission-change-note,
+.submission-change-empty {
+    margin: 0.25rem 0 0.45rem;
+    font-size: 0.75rem;
+}
+.submission-change-table {
+    display: table;
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0.4rem 0 0.55rem;
+    font-size: 0.74rem;
+    table-layout: auto;
+}
+.submission-change-table th,
+.submission-change-table td {
+    padding: 0.18rem 0.38rem;
+    vertical-align: top;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+.submission-change-table td:first-child {
+    width: 1%;
+    white-space: nowrap;
+    font-weight: 600;
+}
+.submission-change-table .review-field-annotation-item {
+    display: inline-block;
+    margin: 0.04rem 0.12rem 0.04rem 0;
+}
+.submission-change-ring {
+    margin: 0.45rem 0 0.6rem;
+}
+.submission-change-ring > strong {
+    display: inline-block;
+    margin-bottom: 0.25rem;
+}
+.submission-change-ring .table-scroll {
+    width: fit-content;
+    max-width: 100%;
+}
+.submission-change-ring-table input[readonly] {
+    cursor: default;
+}
+.submission-change-ring-table .ring-mc { width: 28ch; }
+.submission-change-ring-table .ring-ms { width: 16ch; }
+.submission-change-ring-table .ring-tools { width: 10ch; }
+.submission-change-ring-table .ring-moulds { width: 15ch; }
+.submission-change-ring-table .ring-addmoulds { width: 18ch; }
+.submission-change-ring-table .ring-offset { width: 6ch; }
+.submission-change-ring-table .ring-offset-extra { width: 8ch; }
+.submission-change-ring-table .ring-sample-start { width: 9ch; }
+.submission-change-ring-table .ring-comment { width: 28ch; }
+.submission-change-multiline {
+    margin: 0.45rem 0 0.6rem;
+    padding: 0.35rem 0.5rem;
+}
+.submission-change-text-pair {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    overflow-x: auto;
+}
+.submission-change-text-pair label {
+    flex: 0 0 auto;
+    margin: 0.25rem 0 0;
     font-size: 0.75rem;
     font-weight: 600;
-    line-height: 1.2;
+}
+.submission-change-pre {
+    box-sizing: border-box;
+    width: 46ch;
+    min-height: 2.2rem;
+    max-width: calc(100vw - 3rem);
+    margin: 0.15rem 0 0;
+    padding: 0.45rem 0.55rem;
+    border: var(--pico-border-width) solid var(--pico-form-element-border-color);
+    border-radius: var(--pico-border-radius);
+    background: var(--pico-code-background-color);
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.72rem;
+    line-height: 1.3;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
 }
 
 /* Wrapped text blocks for dump log, comments, etc. */

--- a/templates/disc_edit.html
+++ b/templates/disc_edit.html
@@ -62,19 +62,91 @@ const IS_ADD_MODE = {{ is_add_mode }};
         {% endif %}
     </table>
 
-    {% if !changes_original_json.is_empty() %}
-    <details>
-        <summary>Original JSON</summary>
-        <pre class="raw-json"><code>{{ changes_original_json }}</code></pre>
+    {% for view in change_views %}
+    <details class="submission-change-view" open>
+        <summary>{{ view.title }}</summary>
+        {% if !view.note.is_empty() %}<p class="submission-change-note">{{ view.note }}</p>{% endif %}
+        {% if !view.has_changes %}<p class="submission-change-empty">No recorded changes.</p>{% endif %}
+        {% if !view.scalar_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Field</th><th>Action</th><th>Previous</th><th>Current</th></tr></thead>
+            <tbody>
+            {% for row in view.scalar_rows %}
+                <tr class="{{ row.status_class }}"><td>{{ row.field }}</td><td>{{ row.action }}</td><td>{{ row.previous_value }}</td><td>{{ row.current_value }}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+        {% if !view.set_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Field</th><th>Added</th><th>Removed</th></tr></thead>
+            <tbody>
+            {% for row in view.set_rows %}
+                <tr><td>{{ row.field }}</td><td>{% for item in row.added %}<span class="review-field-annotation-item item-added">{{ item }}</span>{% endfor %}</td><td>{% for item in row.removed %}<span class="review-field-annotation-item item-removed">{{ item }}</span>{% endfor %}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+        {% for section in view.ring_sections %}
+        <section class="submission-change-ring">
+            <strong>{{ section.label }}</strong>
+            <div class="table-scroll table-scroll-compact">
+            <table class="disc-table ring-table ring-edit-table submission-change-ring-table">
+                <thead><tr><th>#</th>{% if section.show_ring_layers %}<th></th>{% endif %}<th>Mastering Code</th><th>Mastering SID</th><th>Toolstamps</th><th>Mould SIDs</th><th>Additional Moulds</th><th>Offset</th><th>Extra Offset</th><th>Sample Start</th><th>Comment</th></tr></thead>
+                <tbody>
+                {% for row in section.ring_rows %}
+                    <tr{% if row.entry_rowspan > 0 && row.entry_num > 1 %} class="ring-group-start"{% endif %}>
+                        {% if row.entry_rowspan > 0 %}<td class="entry-num"{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}>{{ row.entry_num }}</td>{% endif %}
+                        {% if section.show_ring_layers %}<td><strong>{{ row.layer_label }}</strong></td>{% endif %}
+                        <td><input type="text" class="ring-mc{% if !row.mastering_code.status_class.is_empty() %} {{ row.mastering_code.status_class }}{% endif %}" value="{{ row.mastering_code.value }}" readonly></td>
+                        <td><input type="text" class="ring-ms{% if !row.mastering_sid.status_class.is_empty() %} {{ row.mastering_sid.status_class }}{% endif %}" value="{{ row.mastering_sid.value }}" readonly></td>
+                        <td><input type="text" class="ring-tools{% if !row.toolstamps.status_class.is_empty() %} {{ row.toolstamps.status_class }}{% endif %}" value="{{ row.toolstamps.value }}" readonly></td>
+                        <td><input type="text" class="ring-moulds{% if !row.mould_sids.status_class.is_empty() %} {{ row.mould_sids.status_class }}{% endif %}" value="{{ row.mould_sids.value }}" readonly></td>
+                        <td><input type="text" class="ring-addmoulds{% if !row.additional_moulds.status_class.is_empty() %} {{ row.additional_moulds.status_class }}{% endif %}" value="{{ row.additional_moulds.value }}" readonly></td>
+                        {% if row.entry_rowspan > 0 %}
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-offset{% if !row.offset.status_class.is_empty() %} {{ row.offset.status_class }}{% endif %}" value="{{ row.offset.value }}" readonly></td>
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-offset-extra{% if !row.offset_extra.status_class.is_empty() %} {{ row.offset_extra.status_class }}{% endif %}" value="{{ row.offset_extra.value }}" readonly></td>
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-sample-start{% if !row.sample_start.status_class.is_empty() %} {{ row.sample_start.status_class }}{% endif %}" value="{{ row.sample_start.value }}" readonly></td>
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-comment{% if !row.comment.status_class.is_empty() %} {{ row.comment.status_class }}{% endif %}" value="{{ row.comment.value }}" readonly></td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            </div>
+        </section>
+        {% endfor %}
+        {% for row in view.multiline_rows %}
+        <section class="submission-change-multiline {{ row.status_class }}">
+            <strong>{{ row.field }}: {{ row.action }}</strong>
+            <div class="submission-change-text-pair">
+                <label>Previous<pre class="submission-change-pre">{{ row.previous_value }}</pre></label>
+                <label>Current<pre class="submission-change-pre">{{ row.current_value }}</pre></label>
+            </div>
+        </section>
+        {% endfor %}
+        {% if !view.legacy_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Legacy Field</th><th>Action</th><th>Previous</th><th>Current</th></tr></thead>
+            <tbody>
+            {% for row in view.legacy_rows %}
+                <tr class="{{ row.status_class }}"><td>{{ row.field }}</td><td>{{ row.action }}</td><td>{{ row.previous_value }}</td><td>{{ row.current_value }}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+        {% if !view.fallback_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Path</th><th>Value</th></tr></thead>
+            <tbody>
+            {% for row in view.fallback_rows %}
+                <tr><td>{{ row.path }}</td><td>{{ row.value }}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
     </details>
-    {% endif %}
-
-    {% if !changes_json.is_empty() %}
-    <details>
-        <summary>Final JSON</summary>
-        <pre class="raw-json"><code>{{ changes_json }}</code></pre>
-    </details>
-    {% endif %}
+    {% endfor %}
 </div>
 
 {% if !dump_log_display.is_empty() %}

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -5,7 +5,10 @@
 {% block content %}
 <h3 class="downloads-page-title">{{ page_title }}</h3>
 {% if is_disc_history %}
-<p><small>Disc history only shows approved and legacy submissions.</small></p>
+<div class="disc-history-summary">
+    <p><small>Disc history only shows approved and legacy submissions.</small></p>
+    <p><small>{{ total_count }} submission(s) found.</small></p>
+</div>
 {% endif %}
 
 {% if filter_disc_id.is_empty() %}
@@ -66,7 +69,9 @@
 </details>
 {% endif %}
 
+{% if !is_disc_history %}
 <p><small>{{ total_count }} submission(s) found.</small></p>
+{% endif %}
 
 <div id="queue-results">
     {% if total_pages > 1 %}
@@ -84,7 +89,7 @@
     {% endif %}
 
     <div class="table-scroll queue-table-scroll">
-    <table class="disc-table striped table-nowrap queue-table">
+    <table class="disc-table striped table-nowrap queue-table{% if is_disc_history %} queue-history-table{% endif %}">
         <thead>
             <tr>
                 <th class="date-col"><a href="/queue?sort=date&amp;order={{ next_date_order }}&amp;status={{ filter_status }}&amp;sub_type={{ filter_type_url }}&amp;system={{ filter_system }}&amp;submitter={{ filter_submitter_url }}{% if !filter_disc_id.is_empty() %}&amp;disc_id={{ filter_disc_id }}{% endif %}">Date{% if sort_column == "date" %} {% if sort_order == "asc" %}▼{% else %}▲{% endif %}{% endif %}</a></th>
@@ -99,8 +104,12 @@
         </thead>
         <tbody>
             {% for entry in entries %}
-            <tr{% if self.can_open_entry(entry) %} class="clickable-row" data-href="/queue/{{ entry.id }}" tabindex="0" role="link"{% endif %}>
+            <tr{% if !is_disc_history && self.can_open_entry(entry) %} class="clickable-row" data-href="/queue/{{ entry.id }}" tabindex="0" role="link"{% endif %}>
+                {% if is_disc_history %}
+                <td class="date-col"><span class="disc-history-date-cell"><button class="disc-history-toggle" type="button" aria-expanded="false" aria-controls="history-changes-{{ entry.id }}" aria-label="Show changes" title="Show changes"></button><span>{{ entry.created_at.format("%Y-%m-%d %H:%M") }}</span></span></td>
+                {% else %}
                 <td class="date-col">{{ entry.created_at.format("%Y-%m-%d %H:%M") }}</td>
+                {% endif %}
                 <td class="type-col"><span class="{{ self.type_icon_class(entry) }}" role="img" aria-label="{{ self.type_icon_label(entry) }}" title="{{ self.type_icon_label(entry) }}"></span></td>
                 <td class="submission-title-col">{% if self.can_open_entry(entry) %}<a href="/queue/{{ entry.id }}">{{ entry.title }}</a>{% else %}{{ entry.title }}{% endif %}</td>
                 <td class="disc-id-col">{% match entry.target_disc_id %}{% when Some with (disc_id) %}<a href="/disc/{{ disc_id }}">{{ disc_id }}</a>{% when None %}{% endmatch %}</td>
@@ -109,6 +118,99 @@
                 <td class="reviewer-col">{% match entry.reviewer_id %}{% when Some with (_) %}<a href="/discs?dumper={{ self.url_encode(entry.reviewer.as_deref().unwrap_or("")) }}">{{ entry.reviewer.as_deref().unwrap_or("") }}</a>{% when None %}{% endmatch %}</td>
                 <td class="status-col" title="{{ entry.status }}">{% match entry.status %}{% when SubmissionStatus::Pending %}🟡{% when SubmissionStatus::Approved %}🟢{% when SubmissionStatus::Rejected %}🔴{% when SubmissionStatus::Legacy %}⚪{% endmatch %}</td>
             </tr>
+            {% if is_disc_history %}
+            <tr id="history-changes-{{ entry.id }}" class="disc-history-changes-row" hidden>
+                <td colspan="8">
+                    <div class="disc-history-changes">
+                        {% if !entry.submission_comment.is_empty() %}
+                        <section class="disc-history-submission-comment">
+                            <strong>Submission Comment:</strong>
+                            <p class="pre-wrap section-text">{{ entry.submission_comment }}</p>
+                        </section>
+                        {% endif %}
+                        {% if entry.change_details.is_empty() %}
+                        <p>No field-level changes recorded.</p>
+                        {% else %}
+                        {% for change in entry.change_details %}
+                        {% if !change.ring_rows.is_empty() %}
+                        <section class="disc-history-ring-detail field-changed">
+                            <strong class="disc-history-ring-label">{{ change.label }}:</strong>
+                            <div class="table-scroll table-scroll-compact">
+                            <table class="disc-table ring-table ring-edit-table disc-history-ring-table">
+                                <thead>
+                                    <tr>
+                                        <th>#</th>
+                                        {% if change.show_ring_layers %}<th></th>{% endif %}
+                                        <th>Mastering Code</th>
+                                        <th>Mastering SID</th>
+                                        <th>Toolstamps</th>
+                                        <th>Mould SIDs</th>
+                                        <th>Additional Moulds</th>
+                                        <th>Offset</th>
+                                        <th>Comment</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for row in change.ring_rows %}
+                                    <tr{% if row.entry_rowspan > 0 && row.entry_num > 1 %} class="ring-group-start"{% endif %}>
+                                        {% if row.entry_rowspan > 0 %}<td class="entry-num"{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}>{{ row.entry_num }}</td>{% endif %}
+                                        {% if change.show_ring_layers %}<td><strong>{{ row.layer_label }}</strong></td>{% endif %}
+                                        <td><input type="text" class="ring-mc{% if !row.mastering_code.status_class.is_empty() %} {{ row.mastering_code.status_class }}{% endif %}" value="{{ row.mastering_code.value }}" readonly></td>
+                                        <td><input type="text" class="ring-ms{% if !row.mastering_sid.status_class.is_empty() %} {{ row.mastering_sid.status_class }}{% endif %}" value="{{ row.mastering_sid.value }}" readonly></td>
+                                        <td><input type="text" class="ring-tools{% if !row.toolstamps.status_class.is_empty() %} {{ row.toolstamps.status_class }}{% endif %}" value="{{ row.toolstamps.value }}" readonly></td>
+                                        <td><input type="text" class="ring-moulds{% if !row.mould_sids.status_class.is_empty() %} {{ row.mould_sids.status_class }}{% endif %}" value="{{ row.mould_sids.value }}" readonly></td>
+                                        <td><input type="text" class="ring-addmoulds{% if !row.additional_moulds.status_class.is_empty() %} {{ row.additional_moulds.status_class }}{% endif %}" value="{{ row.additional_moulds.value }}" readonly></td>
+                                        {% if row.entry_rowspan > 0 %}
+                                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-offset{% if !row.offset.status_class.is_empty() %} {{ row.offset.status_class }}{% endif %}" value="{{ row.offset.value }}" readonly></td>
+                                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-comment{% if !row.comment.status_class.is_empty() %} {{ row.comment.status_class }}{% endif %}" value="{{ row.comment.value }}" readonly></td>
+                                        {% endif %}
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                            </div>
+                        </section>
+                        {% else %}
+                        {% if change.is_multiline && !change.previous_value.is_empty() %}
+                        <section class="disc-history-multiline-detail multiline-review-field field-changed">
+                            <label>{{ change.label }}
+                                <textarea rows="5" class="hex-dump-input auto-expand fixed-80" readonly>{{ change.current_value }}</textarea>
+                            </label>
+                            <label class="review-old-textarea">Previous
+                                <textarea rows="5" class="hex-dump-input auto-expand fixed-80" readonly>{{ change.previous_value }}</textarea>
+                            </label>
+                        </section>
+                        {% else %}
+                        <section class="disc-history-change-detail inline-field field-changed">
+                            <span class="inline-field-label">{{ change.label }}:</span>
+                            <div class="inline-field-values">
+                                {% if change.is_multiline %}
+                                <textarea class="hex-dump-input fixed-80" rows="4" readonly>{{ change.current_value }}</textarea>
+                                {% else %}
+                                <input type="text" value="{{ change.current_value }}" readonly>
+                                {% endif %}
+                                {% if !change.current_value.is_empty() && !change.current_label.is_empty() %}
+                                <div class="review-field-annotation review-field-annotation-combined">
+                                    <span class="review-field-annotation-label">{{ change.current_label }}:</span>
+                                    <span class="review-field-annotation-item item-{{ change.current_kind }}">{{ change.current_value }}</span>
+                                </div>
+                                {% endif %}
+                                {% if !change.previous_value.is_empty() %}
+                                <div class="review-field-annotation review-field-annotation-combined">
+                                    <span class="review-field-annotation-label">{{ change.previous_label }}:</span>
+                                    <span class="review-field-annotation-item item-{{ change.previous_kind }}">{{ change.previous_value }}</span>
+                                </div>
+                                {% endif %}
+                            </div>
+                        </section>
+                        {% endif %}
+                        {% endif %}
+                        {% endfor %}
+                        {% endif %}
+                    </div>
+                </td>
+            </tr>
+            {% endif %}
             {% endfor %}
             {% if entries.is_empty() %}
             <tr><td colspan="8">No submissions found.</td></tr>
@@ -131,4 +233,54 @@
     </nav>
     {% endif %}
 </div>
+{% if is_disc_history %}
+<script>
+function lockDiscHistoryTableWidth() {
+    var table = document.querySelector('.queue-history-table');
+    if (!table) return;
+    var rows = Array.prototype.slice.call(table.querySelectorAll('.disc-history-changes-row'));
+    if (!rows.length) return;
+
+    table.style.width = 'max-content';
+    table.style.minWidth = 'max-content';
+
+    var widest = Math.ceil(table.getBoundingClientRect().width);
+    rows.forEach(function(row) {
+        var wasHidden = row.hidden;
+        var oldVisibility = row.style.visibility;
+        row.hidden = false;
+        row.style.visibility = 'hidden';
+        widest = Math.max(
+            widest,
+            Math.ceil(table.scrollWidth),
+            Math.ceil(table.getBoundingClientRect().width)
+        );
+        row.hidden = wasHidden;
+        row.style.visibility = oldVisibility;
+    });
+
+    table.style.width = widest + 'px';
+    table.style.minWidth = widest + 'px';
+}
+
+lockDiscHistoryTableWidth();
+window.addEventListener('load', lockDiscHistoryTableWidth, { once: true });
+if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(lockDiscHistoryTableWidth);
+}
+
+document.addEventListener('click', function(event) {
+    var button = event.target.closest('.disc-history-toggle');
+    if (!button) return;
+    var targetId = button.getAttribute('aria-controls');
+    var target = targetId ? document.getElementById(targetId) : null;
+    if (!target) return;
+    var expanded = button.getAttribute('aria-expanded') === 'true';
+    button.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+    button.setAttribute('aria-label', expanded ? 'Show changes' : 'Hide changes');
+    button.title = expanded ? 'Show changes' : 'Hide changes';
+    target.hidden = expanded;
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -12,8 +12,6 @@
 {% endif %}
 
 {% if filter_disc_id.is_empty() %}
-<details open>
-    <summary></summary>
     <form method="get" action="/queue" id="filter-form" class="queue-filter-form">
         <label>
             <span>Status</span>
@@ -66,11 +64,10 @@
         <input type="hidden" name="disc_id" value="{{ filter_disc_id }}">
         {% endif %}
     </form>
-</details>
 {% endif %}
 
 {% if !is_disc_history %}
-<p><small>{{ total_count }} submission(s) found.</small></p>
+<p class="queue-count"><small>{{ total_count }} submission(s) found.</small></p>
 {% endif %}
 
 <div id="queue-results">
@@ -147,6 +144,8 @@
                                         <th>Mould SIDs</th>
                                         <th>Additional Moulds</th>
                                         <th>Offset</th>
+                                        <th>Extra Offset</th>
+                                        <th>Sample Start</th>
                                         <th>Comment</th>
                                     </tr>
                                 </thead>
@@ -162,6 +161,8 @@
                                         <td><input type="text" class="ring-addmoulds{% if !row.additional_moulds.status_class.is_empty() %} {{ row.additional_moulds.status_class }}{% endif %}" value="{{ row.additional_moulds.value }}" readonly></td>
                                         {% if row.entry_rowspan > 0 %}
                                         <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-offset{% if !row.offset.status_class.is_empty() %} {{ row.offset.status_class }}{% endif %}" value="{{ row.offset.value }}" readonly></td>
+                                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-offset-extra{% if !row.offset_extra.status_class.is_empty() %} {{ row.offset_extra.status_class }}{% endif %}" value="{{ row.offset_extra.value }}" readonly></td>
+                                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-sample-start{% if !row.sample_start.status_class.is_empty() %} {{ row.sample_start.status_class }}{% endif %}" value="{{ row.sample_start.value }}" readonly></td>
                                         <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-comment{% if !row.comment.status_class.is_empty() %} {{ row.comment.status_class }}{% endif %}" value="{{ row.comment.value }}" readonly></td>
                                         {% endif %}
                                     </tr>

--- a/templates/queue_detail.html
+++ b/templates/queue_detail.html
@@ -23,19 +23,91 @@
         {% endif %}
     </table>
 
-    {% if !changes_original_json.is_empty() %}
-    <details>
-        <summary>Original JSON</summary>
-        <pre class="raw-json"><code>{{ changes_original_json }}</code></pre>
+    {% for view in change_views %}
+    <details class="submission-change-view" open>
+        <summary>{{ view.title }}</summary>
+        {% if !view.note.is_empty() %}<p class="submission-change-note">{{ view.note }}</p>{% endif %}
+        {% if !view.has_changes %}<p class="submission-change-empty">No recorded changes.</p>{% endif %}
+        {% if !view.scalar_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Field</th><th>Action</th><th>Previous</th><th>Current</th></tr></thead>
+            <tbody>
+            {% for row in view.scalar_rows %}
+                <tr class="{{ row.status_class }}"><td>{{ row.field }}</td><td>{{ row.action }}</td><td>{{ row.previous_value }}</td><td>{{ row.current_value }}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+        {% if !view.set_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Field</th><th>Added</th><th>Removed</th></tr></thead>
+            <tbody>
+            {% for row in view.set_rows %}
+                <tr><td>{{ row.field }}</td><td>{% for item in row.added %}<span class="review-field-annotation-item item-added">{{ item }}</span>{% endfor %}</td><td>{% for item in row.removed %}<span class="review-field-annotation-item item-removed">{{ item }}</span>{% endfor %}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+        {% for section in view.ring_sections %}
+        <section class="submission-change-ring">
+            <strong>{{ section.label }}</strong>
+            <div class="table-scroll table-scroll-compact">
+            <table class="disc-table ring-table ring-edit-table submission-change-ring-table">
+                <thead><tr><th>#</th>{% if section.show_ring_layers %}<th></th>{% endif %}<th>Mastering Code</th><th>Mastering SID</th><th>Toolstamps</th><th>Mould SIDs</th><th>Additional Moulds</th><th>Offset</th><th>Extra Offset</th><th>Sample Start</th><th>Comment</th></tr></thead>
+                <tbody>
+                {% for row in section.ring_rows %}
+                    <tr{% if row.entry_rowspan > 0 && row.entry_num > 1 %} class="ring-group-start"{% endif %}>
+                        {% if row.entry_rowspan > 0 %}<td class="entry-num"{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}>{{ row.entry_num }}</td>{% endif %}
+                        {% if section.show_ring_layers %}<td><strong>{{ row.layer_label }}</strong></td>{% endif %}
+                        <td><input type="text" class="ring-mc{% if !row.mastering_code.status_class.is_empty() %} {{ row.mastering_code.status_class }}{% endif %}" value="{{ row.mastering_code.value }}" readonly></td>
+                        <td><input type="text" class="ring-ms{% if !row.mastering_sid.status_class.is_empty() %} {{ row.mastering_sid.status_class }}{% endif %}" value="{{ row.mastering_sid.value }}" readonly></td>
+                        <td><input type="text" class="ring-tools{% if !row.toolstamps.status_class.is_empty() %} {{ row.toolstamps.status_class }}{% endif %}" value="{{ row.toolstamps.value }}" readonly></td>
+                        <td><input type="text" class="ring-moulds{% if !row.mould_sids.status_class.is_empty() %} {{ row.mould_sids.status_class }}{% endif %}" value="{{ row.mould_sids.value }}" readonly></td>
+                        <td><input type="text" class="ring-addmoulds{% if !row.additional_moulds.status_class.is_empty() %} {{ row.additional_moulds.status_class }}{% endif %}" value="{{ row.additional_moulds.value }}" readonly></td>
+                        {% if row.entry_rowspan > 0 %}
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-offset{% if !row.offset.status_class.is_empty() %} {{ row.offset.status_class }}{% endif %}" value="{{ row.offset.value }}" readonly></td>
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-offset-extra{% if !row.offset_extra.status_class.is_empty() %} {{ row.offset_extra.status_class }}{% endif %}" value="{{ row.offset_extra.value }}" readonly></td>
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-sample-start{% if !row.sample_start.status_class.is_empty() %} {{ row.sample_start.status_class }}{% endif %}" value="{{ row.sample_start.value }}" readonly></td>
+                        <td{% if row.entry_rowspan > 1 %} rowspan="{{ row.entry_rowspan }}"{% endif %}><input type="text" class="ring-comment{% if !row.comment.status_class.is_empty() %} {{ row.comment.status_class }}{% endif %}" value="{{ row.comment.value }}" readonly></td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            </div>
+        </section>
+        {% endfor %}
+        {% for row in view.multiline_rows %}
+        <section class="submission-change-multiline {{ row.status_class }}">
+            <strong>{{ row.field }}: {{ row.action }}</strong>
+            <div class="submission-change-text-pair">
+                <label>Previous<pre class="submission-change-pre">{{ row.previous_value }}</pre></label>
+                <label>Current<pre class="submission-change-pre">{{ row.current_value }}</pre></label>
+            </div>
+        </section>
+        {% endfor %}
+        {% if !view.legacy_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Legacy Field</th><th>Action</th><th>Previous</th><th>Current</th></tr></thead>
+            <tbody>
+            {% for row in view.legacy_rows %}
+                <tr class="{{ row.status_class }}"><td>{{ row.field }}</td><td>{{ row.action }}</td><td>{{ row.previous_value }}</td><td>{{ row.current_value }}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+        {% if !view.fallback_rows.is_empty() %}
+        <table class="disc-table submission-change-table">
+            <thead><tr><th>Path</th><th>Value</th></tr></thead>
+            <tbody>
+            {% for row in view.fallback_rows %}
+                <tr><td>{{ row.path }}</td><td>{{ row.value }}</td></tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
     </details>
-    {% endif %}
-
-    {% if !changes_json.is_empty() %}
-    <details>
-        <summary>Final JSON</summary>
-        <pre class="raw-json"><code>{{ changes_json }}</code></pre>
-    </details>
-    {% endif %}
+    {% endfor %}
 </div>
 
 {% if !dump_log_display.is_empty() %}


### PR DESCRIPTION
## Summary
- add collapsible disc History rows that show field-level changes using the queue edit review presentation
- replace raw submission change JSON on review/detail pages with structured human-readable change panels
- render scalar, set, multiline, legacy, fallback, and ring-code changes, including Extra Offset and Sample Start
- keep Queue filters always visible and center the Queue submission count

## Validation
- cargo build
- cargo test routes::queue::tests
- docker compose up -d --build app
- full container test suite: 336 passed; 0 failed; 7 ignored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more readable submission changes view across queue, detail, and edit screens, replacing raw JSON with structured tables and sections.
  * Queue history now supports expandable per-entry change details, including submission comments and field-level change breakdowns.
  * Improved disc history pages with clearer summary text and toggle controls for viewing approved and legacy submissions.

* **Bug Fixes**
  * Preserved change information more consistently when loading submission lists and review pages.
  * Adjusted layout and spacing for change details and history tables for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->