### PR TITLE
One line per dumper

### DIFF
--- a/src/routes/disc_view.rs
+++ b/src/routes/disc_view.rs
@@ -783,7 +783,11 @@ async fn disc_view(
                         )
                     })
                     .collect::<Vec<_>>()
-                    .join(", ")
+                    .join(if detail.dumpers.len() <= 10 {
+                        "<br>"
+                    } else {
+                        ", "
+                    })
             },
             ring_vis: RingColVis::from_rows(
                 &ring_rows,


### PR DESCRIPTION
Fixes #172.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dumper list readability by displaying shorter lists on separate lines and longer lists with comma-separated links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->